### PR TITLE
Memory Exhaustion issue - added limit to query

### DIFF
--- a/index.php
+++ b/index.php
@@ -1098,7 +1098,7 @@ function simple_history_get_items_array($args = "") {
 	$tableprefix = $wpdb->prefix;
 
 	$sql = "SELECT * FROM {$tableprefix}simple_history $where ORDER BY date DESC, id DESC ";
-        $sql .= "LIMIT " . ($args['page']+1) * $args['items'] . ',' . $args['items'];
+        $sql .= "LIMIT " . ($args['page'] * $args['items']) . ',' . $args['items'];
         $sql .= ';';
 	#sf_d($args);
 	#echo "\n$sql\n";


### PR DESCRIPTION
calling simple_history_get_items_array can cause a memory exhaustion error. 

Using the following code in a custom plugin/theme to show the history, we get an exhaustion error.

``` PHP
$args = array("filter_user" => $current_user_id);
$logs = simple_history_get_items_array($args);
```

Added the SQL update to use a limit based on page and pager amount to prevent this.
