### PR TITLE
Add support for WPMU plugins

### DIFF
--- a/inc/SimpleHistory.php
+++ b/inc/SimpleHistory.php
@@ -984,13 +984,11 @@ class SimpleHistory {
 
 			add_thickbox();
 
-			$plugin_url = plugin_dir_url(SIMPLE_HISTORY_BASENAME);
+			wp_enqueue_style("simple_history_styles", SIMPLE_HISTORY_BASENAME . "css/styles.css", false, SIMPLE_HISTORY_VERSION);
+			wp_enqueue_script("simple_history_script", SIMPLE_HISTORY_BASENAME . "js/scripts.js", array("jquery", "backbone", "wp-util"), SIMPLE_HISTORY_VERSION, true);
 
-			wp_enqueue_style("simple_history_styles", $plugin_url . "css/styles.css", false, SIMPLE_HISTORY_VERSION);
-			wp_enqueue_script("simple_history_script", $plugin_url . "js/scripts.js", array("jquery", "backbone", "wp-util"), SIMPLE_HISTORY_VERSION, true);
-
-			wp_enqueue_script("select2", $plugin_url . "js/select2/select2.min.js", array("jquery"));
-			wp_enqueue_style("select2", $plugin_url . "js/select2/select2.css");
+			wp_enqueue_script("select2", SIMPLE_HISTORY_BASENAME . "js/select2/select2.min.js", array("jquery"));
+			wp_enqueue_style("select2", SIMPLE_HISTORY_BASENAME . "js/select2/select2.css");
 
 			// Translations that we use in JavaScript
 			wp_localize_script('simple_history_script', 'simple_history_script_vars', array(

--- a/index.php
+++ b/index.php
@@ -44,20 +44,18 @@ if ( version_compare( phpversion(), "5.3", ">=") ) {
 	 */
 	// register_activation_hook( trailingslashit(WP_PLUGIN_DIR) . trailingslashit( plugin_basename(__DIR__) ) . "index.php" , array("SimpleHistory", "on_plugin_activate" ) );
 
-	define( 'SIMPLE_HISTORY_VERSION', '2.1.1' );
-
-	//define( 'SIMPLE_HISTORY_FILE', __FILE__ );
-	//define( 'SIMPLE_HISTORY_PATH', plugin_dir_path( SIMPLE_HISTORY_FILE ) );
-	//define( 'SIMPLE_HISTORY_BASENAME', plugin_basename( SIMPLE_HISTORY_FILE ) );
+	if ( ! defined( 'SIMPLE_HISTORY_VERSION' ) ) {
+		define( 'SIMPLE_HISTORY_VERSION', '2.1.1' );
+	}
 
 	if ( ! defined( 'SIMPLE_HISTORY_PATH' ) ) {
 		define( 'SIMPLE_HISTORY_PATH', plugin_dir_path( __FILE__ ) );
 	}
-	// Plugin URL
+
 	if ( ! defined( 'SIMPLE_HISTORY_BASENAME' ) ) {
 		define( 'SIMPLE_HISTORY_BASENAME', plugin_dir_url( __FILE__ ) );
 	}
-	// Plugin Root File
+
 	if ( ! defined( 'SIMPLE_HISTORY_FILE' ) ) {
 		define( 'SIMPLE_HISTORY_FILE', __FILE__ );
 	}

--- a/index.php
+++ b/index.php
@@ -46,10 +46,22 @@ if ( version_compare( phpversion(), "5.3", ">=") ) {
 
 	define( 'SIMPLE_HISTORY_VERSION', '2.1.1' );
 
-	define( 'SIMPLE_HISTORY_FILE', __FILE__ );
-	define( 'SIMPLE_HISTORY_PATH', plugin_dir_path( SIMPLE_HISTORY_FILE ) );
-	define( 'SIMPLE_HISTORY_BASENAME', plugin_basename( SIMPLE_HISTORY_FILE ) );
-	
+	//define( 'SIMPLE_HISTORY_FILE', __FILE__ );
+	//define( 'SIMPLE_HISTORY_PATH', plugin_dir_path( SIMPLE_HISTORY_FILE ) );
+	//define( 'SIMPLE_HISTORY_BASENAME', plugin_basename( SIMPLE_HISTORY_FILE ) );
+
+	if ( ! defined( 'SIMPLE_HISTORY_PATH' ) ) {
+		define( 'SIMPLE_HISTORY_PATH', plugin_dir_path( __FILE__ ) );
+	}
+	// Plugin URL
+	if ( ! defined( 'SIMPLE_HISTORY_BASENAME' ) ) {
+		define( 'SIMPLE_HISTORY_BASENAME', plugin_dir_url( __FILE__ ) );
+	}
+	// Plugin Root File
+	if ( ! defined( 'SIMPLE_HISTORY_FILE' ) ) {
+		define( 'SIMPLE_HISTORY_FILE', __FILE__ );
+	}
+
 	// Constants will be like:
 	/*
 	SIMPLE_HISTORY_FILE:


### PR DESCRIPTION
I wanted to use Wordpress-Simple-History as a mu-plugins but It was possible due to wrong file path.

Made two quick modification and the plugin is now compatible as a WPMU plugin.

