### PR TITLE
Add if not exists to table and add column sql

### DIFF
--- a/inc/SimpleHistory.php
+++ b/inc/SimpleHistory.php
@@ -752,7 +752,7 @@ class SimpleHistory {
 			$loopNum = 0;
 
 			$arr_messages_by_message_key = array();
-			
+
 			foreach ( $loggerInfo["messages"] as $message_key => $message_untranslated ) {
 
 				// Find message in array with both translated and non translated strings
@@ -1122,7 +1122,7 @@ class SimpleHistory {
 
 			// We change the varchar size to add one num just to force update of encoding. dbdelta didn't see it otherwise.
 			// This table is missing action_description, but we add that later on
-			$sql = "CREATE TABLE " . $table_name . " (
+			$sql = "CREATE TABLE IF NOT EXISTS " . $table_name . " (
 			  id bigint(20) NOT NULL AUTO_INCREMENT,
 			  date datetime NOT NULL,
 			  action VARCHAR(256) NOT NULL COLLATE utf8_general_ci,
@@ -1157,7 +1157,7 @@ class SimpleHistory {
 		if ( 1 == intval( $db_version ) ) {
 
 			// Add column for action description in non-translatable free text
-			$sql = "ALTER TABLE {$table_name} ADD COLUMN action_description longtext";
+			$sql = "ALTER TABLE {$table_name} ADD COLUMN IF NOT EXISTS action_description longtext";
 			$wpdb->query( $sql );
 
 			$db_version_prev = $db_version;
@@ -1203,7 +1203,7 @@ class SimpleHistory {
 
 			// Update old table
 			$sql = "
-				CREATE TABLE {$table_name} (
+				CREATE TABLE IF NOT EXISTS {$table_name} (
 				  id bigint(20) NOT NULL AUTO_INCREMENT,
 				  date datetime NOT NULL,
 				  logger varchar(30) DEFAULT NULL,
@@ -1228,7 +1228,7 @@ class SimpleHistory {
 
 			// Add context table
 			$sql = "
-				CREATE TABLE {$table_name_contexts} (
+				CREATE TABLE IF NOT EXISTS {$table_name_contexts} (
 				  context_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 				  history_id bigint(20) unsigned NOT NULL,
 				  `key` varchar(255) DEFAULT NULL,


### PR DESCRIPTION
When running unit tests for a site where simple history is a must use plugin it will try to create the table and add column more then once. Adding `if not exists` to create table and add column sql will solve it.