### PR TITLE
Disabling RSS by default

### DIFF
--- a/dropins/SimpleHistoryRSSDropin.php
+++ b/dropins/SimpleHistoryRSSDropin.php
@@ -21,7 +21,7 @@ class SimpleHistoryRSSDropin {
 			require_once( ABSPATH . '/wp-admin/includes/user.php' );
 		}
 		
-		//Check the status og the RSS feed
+		//Check the status of the RSS feed
 		$this->is_rss_enabled();
 
 		// Generate a rss secret, if it does not exist

--- a/dropins/SimpleHistoryRSSDropin.php
+++ b/dropins/SimpleHistoryRSSDropin.php
@@ -41,6 +41,9 @@ class SimpleHistoryRSSDropin {
 	 * + also regenerates the secret if requested
 	 */
 	public function add_settings() {
+		
+		//we register a setting to keep track of the RSS feed status (enabled/disabled)
+		register_setting( 'simple_history_settings_group', 'simple_history_enable_rss_feed', array($this, 'update_rss_status') );
 
 		/**
 		 * Start new section for RSS feed
@@ -52,6 +55,15 @@ class SimpleHistoryRSSDropin {
 			_x("RSS feed", "rss settings headline", "simple-history"), // No title __("General", "simple-history"),
 			array($this, "settings_section_output"),
 			SimpleHistory::SETTINGS_MENU_SLUG // same slug as for options menu page
+		);
+		
+		// Enable/Disabled RSS feed
+		add_settings_field(
+			"simple_history_enable_rss_feed",
+			__("Enable", "simple-history"),
+			array($this, "settings_field_rss_enable"),
+			SimpleHistory::SETTINGS_MENU_SLUG,
+			$settings_section_rss_id
 		);
 		
 		//if RSS is activated we display other fields
@@ -122,6 +134,33 @@ class SimpleHistoryRSSDropin {
 		
 		return false;
 
+	}
+	
+	/**
+	 * Output for settings field that show current RSS address
+	 */
+	function settings_field_rss_enable() {
+		
+		?>
+		
+		<input value="1" type="checkbox" name="simple_history_enable_rss_feed" <?php checked( $this->is_rss_enabled(), 1 ); ?> />
+		<label for="simple_history_enable_rss_feed"><?php _e( "enable RSS feed", 'simple-history' )?></label>
+		
+		<?php
+
+	}
+	
+	/**
+	 * Sanitize RSS enabled/disabled status on update settings
+	 */
+	function update_rss_status($field) {
+
+		if( $field === "1" ){
+			return "1";
+		}
+		
+		return "0";
+		
 	}
 
 


### PR DESCRIPTION
- RSS feed is now disabled by default however it stays activated if you were already using the plugin (to prevent breaking change).
- There is now a GUI admin setting to enable/disable RSS feed

I tested the changes in multiple use cases (fresh install, existing install, etc...)

Closing #91