### PR TITLE
Apply addslashes to slug for namespaced Logger classes

### DIFF
--- a/inc/SimpleHistory.php
+++ b/inc/SimpleHistory.php
@@ -2553,7 +2553,7 @@ Because Simple History was just recently installed, this feed does not contain m
 
 					$str_return .= sprintf(
 						'"%1$s", ',
-						$one_logger["instance"]->slug
+						addslashes($one_logger["instance"]->slug)
 					);
 
 				}


### PR DESCRIPTION
I figured it out. Since I was using a namespace, the SQL query was incorrect because of the backslashes and I was referencing the slug via `__CLASS__`, as per the example.

I applied `addslashes()` to the method that outputs the  This should solve the issue I was having on #103. Ran `phpunit` and shows all green.

In the meantime, I renamed the slug of my logger to not include backslashes and updated the database entries manually.