### PR TITLE
Fix notice error from User logger

### DIFF
--- a/loggers/SimpleUserLogger.php
+++ b/loggers/SimpleUserLogger.php
@@ -828,6 +828,7 @@ class SimpleUserLogger extends SimpleLogger {
 		$message_key = $context["_message_key"];
 
 		$out = "";
+		$diff_table_output = "";
 
 		if ( "user_updated_profile" == $message_key ) {
 
@@ -884,8 +885,6 @@ class SimpleUserLogger extends SimpleLogger {
 					"title" => _x("Role", "User logger", "simple-history")
 				)
 			);
-
-			$diff_table_output = "";
 
 			foreach ( $arr_user_keys_to_show_diff_for as $key => $val ) {
 


### PR DESCRIPTION
Hi :)
A little bug : $diff_table_output might have not been defined at line 1001 and 1005 which causes notices errors.