### PR TITLE
Remove static from SimpleLogger class

### DIFF
--- a/loggers/SimpleLogger.php
+++ b/loggers/SimpleLogger.php
@@ -677,7 +677,7 @@ class SimpleLogger {
 	 * @param array $context
 	 * @return null
 	 */
-	public static function emergency($message, array $context = array()) {
+	public function emergency($message, array $context = array()) {
 
 		return $this->log(SimpleLoggerLogLevels::EMERGENCY, $message, $context);
 
@@ -744,7 +744,7 @@ class SimpleLogger {
 	 * @param array $context
 	 * @return null
 	 */
-	public static function alert($message, array $context = array()) {
+	public function alert($message, array $context = array()) {
 		return $this->log(SimpleLoggerLogLevels::ALERT, $message, $context);
 
 	}
@@ -771,7 +771,7 @@ class SimpleLogger {
 	 * @param array $context
 	 * @return null
 	 */
-	public static function critical($message, array $context = array()) {
+	public function critical($message, array $context = array()) {
 
 		return $this->log(SimpleLoggerLogLevels::CRITICAL, $message, $context);
 


### PR DESCRIPTION
Hi :),

I don't understand why but there are static functions which contain `$this` inside `SimpleLogger` class .

So, they cause fatal error when we call them like this 

`SimpleLogger()->critical('Mayday, mayday !!');`


_Otherwise, I still love your plugin, continue like this_  :heart_eyes:
