### PR TITLE
Fix PHP 7 and/or Membership 2 compatibility issue

### DIFF
--- a/loggers/SimpleUserLogger.php
+++ b/loggers/SimpleUserLogger.php
@@ -314,7 +314,7 @@ class SimpleUserLogger extends SimpleLogger
      * user requests a reset password link
      *
      */
-    public function onRetrievePasswordMessage($message, $key, $user_login, $user_data)
+    public function onRetrievePasswordMessage($message, $key, $user_login, $user_data = "")
     {
 
         if (isset($_GET["action"]) && ("lostpassword" == $_GET["action"])) {


### PR DESCRIPTION
I have a site running Membership 2 and PHP 7.1 (might be a compatibility issue with just one or the other or both), and I couldn't get the Lost Password form submission to be completed due to a fatal server error caused by this one function parameter being seen as required when the password reset form was only supplying 3 of them. This patch makes it so that 4th parameter is optional & doesn't throw a fatal server error.

I'd love to see this included in a future version as it's harmless while addressing a potential server error.