### PR TITLE
Fix fatal PHP 7.1 error with sites where the $actions pulls as a string instead of an array

### DIFF
--- a/inc/SimpleHistory.php
+++ b/inc/SimpleHistory.php
@@ -1341,6 +1341,11 @@ class SimpleHistory {
 
 		$settings_page_url = menu_page_url( SimpleHistory::SETTINGS_MENU_SLUG, 0 );
 
+		if(empty($actions)){ // Create array if actions is empty (and therefore is assumed to be a string by PHP & results in PHP 7.1+ fatal error due to trying to make array modifications on what's assumed to be a string)
+			$actions = array();
+		}elseif(is_string($actions)){ // Convert the string (which it might've been retrieved as) to an array for future use as an array
+			$actions = array($actions);
+		}
 		$actions[] = "<a href='$settings_page_url'>" . __( 'Settings', 'simple-history' ) . '</a>';
 
 		return $actions;


### PR DESCRIPTION
PHP 7.1 has a fatal error when `$actions[] = "<a href='$settings_page_url'>" . __( 'Settings', 'simple-history' ) . '</a>';` is executed when it's been handed `$actions` being a string instead of an array. I'm assuming PHP 7.1 doesn't do this automatic string to array conversion anymore due to performance reasons.

I would love to see this officially adopted in a future version of the plugin as I'm thinking others out there might encounter this issue after updating their hosting environment to PHP 7.1+. As an aside, I'm thinking this might only trigger an issue on WordPress sites which have been active for a few years since it's an older site (though running WP 4.9) that had an issue while I have other similar sites on the same setup without this issue. Either way, it'd be good to accommodate for this potential fatal error.

I have also posted this on the WP.org support forums at: https://wordpress.org/support/topic/fix-fatal-php-7-1-error-with-sites-where-the-actions-pulls-as-a-string/

Thanks for the great plugin!