### PR TITLE
Fix warning for missing Logger->messages

### DIFF
--- a/loggers/SimpleCategoriesLogger.php
+++ b/loggers/SimpleCategoriesLogger.php
@@ -24,19 +24,23 @@ class SimpleCategoriesLogger extends SimpleLogger {
 				'deleted_term' => __( 'Deleted term "{term_name}" from taxonomy "{term_taxonomy}"', 'simple-history' ),
 				'edited_term' => __( 'Edited term "{to_term_name}" in taxonomy "{to_term_taxonomy}"', 'simple-history' ),
 			),
-			/*
-			"labels" => array(
-				"search" => array(
-					"label" => _x("WordPress Core", "User logger: search", "simple-history"),
-					"options" => array(
-						_x("WordPress core updates", "User logger: search", "simple-history") => array(
-							"core_updated",
-							"core_auto_updated"
+			'labels' => array(
+				'search' => array(
+					'label' => _x( 'Categories', 'Categories logger: search', 'simple-history'),
+					'label_all' => _x( 'All category activity', 'Category logger: search', 'simple-history' ),
+					'options' => array(
+						_x( 'Term created', 'Category logger: search', 'simple-history' ) => array(
+							'created_term'
+						),
+						_x( 'Term deleted', 'Category logger: search', 'simple-history' ) => array(
+							'deleted_term'
+						),
+						_x( 'Term edited', 'Category logger: search', 'simple-history' ) => array(
+							'edited_term'
 						),
 					)
 				) // end search array
 			) // end labels
-			*/
 		);
 
 		return $arr_info;


### PR DESCRIPTION
Hi! 👋🏼

We were having a bunch of warnings added to the error log, going onto investigating it turned me to the value `SimpleCategoriesLogger->messages` being `null`. 

Took a bit of figuring out, but I believe this should fix it properly for your plugin, the warnings are all gone at least :-)

```
PHP Warning:  Invalid argument supplied for foreach() in /wp-content/plugins/simple-history/inc/SimpleHistory.php on line 1159
PHP Stack trace:
...
PHP   3. require_once() /wp-admin/admin-ajax.php:22
PHP   4. require_once() /wp-load.php:42
PHP   5. require_once() /wp-config.php:58
PHP   6. do_action($tag = *uninitialized*, $arg = *uninitialized*) /wp-settings.php:434
PHP   7. WP_Hook->do_action($args = *uninitialized*) /wp-includes/plugin.php:453
PHP   8. WP_Hook->apply_filters($value = *uninitialized*, $args = *uninitialized*) /wp-includes/class-wp-hook.php:310
PHP   9. SimpleHistory->load_loggers(*uninitialized*) /wp-includes/class-wp-hook.php:286
```