### PR TITLE
Fix join parameter order for PHP 7.4

### DIFF
--- a/templates/settings-statsForGeeks.php
+++ b/templates/settings-statsForGeeks.php
@@ -1,11 +1,10 @@
 <?php
-defined('ABSPATH') or die();
-?>
+defined('ABSPATH') or die(); ?>
 
 <script>
-    
+
     jQuery(function($) {
-        
+
         var $button = $(".js-SimpleHistoryShowsStatsForGeeks");
         var $wrapper = $(".SimpleHistory__statsForGeeksInner");
 
@@ -18,21 +17,18 @@ defined('ABSPATH') or die();
 
 </script>
 <?php
-
-defined('ABSPATH') or exit;
+defined('ABSPATH') or exit();
 
 echo '<hr>';
 echo "<p class='hide-if-no-js'><button class='button js-SimpleHistoryShowsStatsForGeeks'>Show stats for geeks</button></p>";
-
 ?>
 
 <div class="SimpleHistory__statsForGeeksInner hide-if-js">
     <?php
-
     echo '<h4>Rows count</h4>';
     $logQuery = new SimpleHistoryLogQuery();
     $rows = $logQuery->query(array(
-        'posts_per_page' => 1,
+        'posts_per_page' => 1
         // "date_from" => strtotime("-$period_days days")
     ));
 
@@ -52,9 +48,9 @@ echo "<p class='hide-if-no-js'><button class='button js-SimpleHistoryShowsStatsF
 
     $sql_table_size = sprintf(
         '
-		SELECT table_name AS "table_name", 
-		round(((data_length + index_length) / 1024 / 1024), 2) "size_in_mb" 
-		FROM information_schema.TABLES 
+		SELECT table_name AS "table_name",
+		round(((data_length + index_length) / 1024 / 1024), 2) "size_in_mb"
+		FROM information_schema.TABLES
 		WHERE table_schema = "%1$s"
 		AND table_name IN ("%2$s", "%3$s");
 		',
@@ -64,7 +60,6 @@ echo "<p class='hide-if-no-js'><button class='button js-SimpleHistoryShowsStatsF
     );
 
     $table_size_result = $wpdb->get_results($sql_table_size);
-
 
     echo '<h4>Database size</h4>';
 
@@ -119,13 +114,17 @@ echo "<p class='hide-if-no-js'><button class='button js-SimpleHistoryShowsStatsF
         $arr_logger_slugs[] = $oneLogger['instance']->slug;
     }
 
-    $sql_logger_counts = sprintf('
+    $sql_logger_counts = sprintf(
+        '
 		SELECT logger, count(id) as count
 		FROM %1$s
 		WHERE logger IN ("%2$s")
 		GROUP BY logger
 		ORDER BY count DESC
-	', $table_name, join($arr_logger_slugs, '","'));
+	',
+        $table_name,
+        join('","', $arr_logger_slugs)
+    );
 
     $logger_rows_count = $wpdb->get_results($sql_logger_counts, OBJECT_K);
 
@@ -134,15 +133,15 @@ echo "<p class='hide-if-no-js'><button class='button js-SimpleHistoryShowsStatsF
     foreach ($arr_logger_slugs as $one_logger_slug) {
         $logger = $this->sh->getInstantiatedLoggerBySlug($one_logger_slug);
 
-        if (! $logger) {
+        if (!$logger) {
             continue;
         }
 
-        if (isset($logger_rows_count[ $one_logger_slug ])) {
-            $one_logger_count = $logger_rows_count[ $one_logger_slug ];
+        if (isset($logger_rows_count[$one_logger_slug])) {
+            $one_logger_count = $logger_rows_count[$one_logger_slug];
         } else {
             // logger was not is sql result, so fake result
-            $one_logger_count = new stdclass;
+            $one_logger_count = new stdclass();
             $one_logger_count->count = 0;
         }
 
@@ -180,8 +179,7 @@ echo "<p class='hide-if-no-js'><button class='button js-SimpleHistoryShowsStatsF
         );
 
         $loopnum++;
-    }// End foreach().
+    } // End foreach().
     echo '</table>';
-
     ?>
 </div><!-- // stats for geeks inner -->

--- a/templates/settings-statsLoggers.php
+++ b/templates/settings-statsLoggers.php
@@ -17,14 +17,14 @@ $sql_logger_counts = sprintf(
     '
 	SELECT logger, count(id) as count
 	FROM %1$s
-	WHERE 
+	WHERE
 		logger IN ("%2$s")
 		AND UNIX_TIMESTAMP(date) >= %3$d
 	GROUP BY logger
 	ORDER BY count DESC
 	',
     $table_name, // 1
-    join($arr_logger_slugs, '","'), // 2
+    join('","', $arr_logger_slugs), // 2
     strtotime("-$period_days days")
 );
 
@@ -42,7 +42,7 @@ $max_loggers_in_chart = sizeof($arr_colors);
 foreach ($logger_rows_count as $one_logger_count) {
     $logger = $this->sh->getInstantiatedLoggerBySlug($one_logger_count->logger);
 
-    if (! $logger) {
+    if (!$logger) {
         continue;
     }
 
@@ -61,7 +61,7 @@ foreach ($logger_rows_count as $one_logger_count) {
 			},',
         $one_logger_count->count, // 1
         $logger_info['name'], // 2
-        $arr_colors[ $i ] // 3
+        $arr_colors[$i] // 3
     );
 
     $str_js_chart_data_chartist .= sprintf(
@@ -69,10 +69,7 @@ foreach ($logger_rows_count as $one_logger_count) {
         $one_logger_count->count // 1
     );
 
-    $str_js_chart_labels .= sprintf(
-        '"%1$s",',
-        $logger_info['name']
-    );
+    $str_js_chart_labels .= sprintf('"%1$s",', $logger_info['name']);
 
     $str_js_google_chart_data .= sprintf(
         '["%1$s", %2$d], ',
@@ -81,40 +78,39 @@ foreach ($logger_rows_count as $one_logger_count) {
     );
 
     $i++;
-}// End foreach().
+} // End foreach().
 $str_js_chart_data = rtrim($str_js_chart_data, ',');
 $str_js_chart_data_chartist = rtrim($str_js_chart_data_chartist, ',');
 $str_js_chart_labels = rtrim($str_js_chart_labels, ',');
 $str_js_google_chart_data = rtrim($str_js_google_chart_data, ',');
-
 ?>
 <script>
-    
+
     /**
      * Pie chart with loggers distribution
      */
     jQuery(function($) {
 
-        /*      
+        /*
         var data = {
-            series: [<?php echo $str_js_chart_data_chartist ?>],
-            labels: [<?php echo $str_js_chart_labels ?>]
-        };      
-        
+            series: [<?php echo $str_js_chart_data_chartist; ?>],
+            labels: [<?php echo $str_js_chart_labels; ?>]
+        };
+
         var options = {};
 
         Chartist.Pie(".SimpleHistoryChart__loggersPie", data, options);
         */
 
         var data = google.visualization.arrayToDataTable([
-            <?php echo $str_js_google_chart_data ?>
+            <?php echo $str_js_google_chart_data; ?>
         ]);
 
         var options = {
             xtitle: 'My Daily Activities',
             backgroundColor: "transparent",
             is3D: true,
-            legend: { 
+            legend: {
                 xposition: 'top',
                 alignment: 'center'
             }
@@ -123,7 +119,7 @@ $str_js_google_chart_data = rtrim($str_js_google_chart_data, ',');
 
         var chart = new google.visualization.PieChart( $(".SimpleHistoryChart__loggersPieGoogleChart").get(0) );
         chart.draw(data, options);
-        
+
         //var chart2 = new google.visualization.BarChart( $(".SimpleHistoryChart__loggersGoogleBarChart").get(0) );
         //chart2.draw(data, options);
 

--- a/templates/template-settings-tab-debug.php
+++ b/templates/template-settings-tab-debug.php
@@ -22,7 +22,6 @@ $period_end_date = DateTime::createFromFormat('U', time());
 
 echo '<h3>' . _x('Database size', 'debug dropin', 'simple-history') . '</h3>';
 
-
 // Get table sizes in mb.
 $sql_table_size = sprintf(
     '
@@ -63,15 +62,9 @@ printf(
 
 $loopnum = 0;
 foreach ($table_size_result as $one_table) {
-    $size = sprintf(
-        _x('%s MB', 'debug dropin', 'simple-history'),
-        $one_table->size_in_mb
-    );
+    $size = sprintf(_x('%s MB', 'debug dropin', 'simple-history'), $one_table->size_in_mb);
 
-    $rows = sprintf(
-        _x('%s rows', 'debug dropin', 'simple-history'),
-        number_format_i18n($one_table->num_rows, 0)
-    );
+    $rows = sprintf(_x('%s rows', 'debug dropin', 'simple-history'), number_format_i18n($one_table->num_rows, 0));
 
     printf(
         '<tr class="%4$s">
@@ -92,7 +85,7 @@ echo '</table>';
 
 $logQuery = new SimpleHistoryLogQuery();
 $rows = $logQuery->query(array(
-    'posts_per_page' => 1,
+    'posts_per_page' => 1
 ));
 
 // This is the number of rows with occasions taken into consideration
@@ -104,7 +97,6 @@ printf(
     $total_accassions_rows_count
 );
 echo '</p>';
-
 
 // echo "<h4>Clear history interval</h4>";
 // echo "<p>" . $this->sh->get_clear_history_interval() . "</p>";
@@ -121,13 +113,17 @@ foreach ($this->sh->getInstantiatedLoggers() as $oneLogger) {
     $arr_logger_slugs[] = $oneLogger['instance']->slug;
 }
 
-$sql_logger_counts = sprintf('
+$sql_logger_counts = sprintf(
+    '
     SELECT logger, count(id) as count
     FROM %1$s
     WHERE logger IN ("%2$s")
     GROUP BY logger
     ORDER BY count DESC
-', $table_name, join($arr_logger_slugs, '","'));
+',
+    $table_name,
+    join('","', $arr_logger_slugs)
+);
 
 $logger_rows_count = $wpdb->get_results($sql_logger_counts, OBJECT_K);
 
@@ -135,9 +131,9 @@ $logger_rows_count = $wpdb->get_results($sql_logger_counts, OBJECT_K);
 $missing_logger_slugs = array_diff($arr_logger_slugs, array_keys($logger_rows_count));
 
 foreach ($missing_logger_slugs as $one_missing_logger_slug) {
-    $logger_rows_count[ $one_missing_logger_slug ] = (object) array(
+    $logger_rows_count[$one_missing_logger_slug] = (object) array(
         'logger' => $one_missing_logger_slug,
-        'count' => 0,
+        'count' => 0
     );
 }
 
@@ -179,15 +175,15 @@ $loopnum = 0;
 foreach ($logger_rows_count as $one_logger_slug => $one_logger_val) {
     $logger = $this->sh->getInstantiatedLoggerBySlug($one_logger_slug);
 
-    if (! $logger) {
+    if (!$logger) {
         continue;
     }
 
-    if (isset($logger_rows_count[ $one_logger_slug ])) {
-        $one_logger_count = $logger_rows_count[ $one_logger_slug ];
+    if (isset($logger_rows_count[$one_logger_slug])) {
+        $one_logger_count = $logger_rows_count[$one_logger_slug];
     } else {
         // logger was not is sql result, so fake result
-        $one_logger_count = new stdclass;
+        $one_logger_count = new stdclass();
         $one_logger_count->count = 0;
     }
 
@@ -253,7 +249,7 @@ foreach ($logger_rows_count as $one_logger_slug => $one_logger_val) {
     );
 
     $loopnum++;
-}// End foreach().
+} // End foreach().
 
 echo '</table>';
 
@@ -291,9 +287,7 @@ foreach ($plugins as $pluginFilePath => $onePlugin) {
         ',
         esc_html($onePlugin['Name']),
         esc_html($pluginFilePath),
-        $isPluginActive ?
-            _x('Yes', 'debug dropin', 'simple-history') :
-            _x('No', 'debug dropin', 'simple-history')
+        $isPluginActive ? _x('Yes', 'debug dropin', 'simple-history') : _x('No', 'debug dropin', 'simple-history')
         // 3
     );
 }


### PR DESCRIPTION
As of PHP 7.4, the `implode` and `join` functions require that the `$glue` and `$pieces` parameters be passed in that specific order, passing them in the reverse order will now generate a warning. This has been [addressed in WordPress core](https://core.trac.wordpress.org/ticket/47746) for v5.3.