### PR TITLE
Adjust pagination styles to match WordPress Core

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -550,11 +550,8 @@ i.e. the log is inside a .postbox element
 	line-height: 1.5;
 }
 
-.postbox .SimpleHistoryPaginationLink,
 .postbox .SimpleHistoryPaginationCurrentPage {
-	font-size: 13px;
-	line-height: 19px;
-	height: 24px;
+	vertical-align: top;
 }
 
 /*
@@ -599,18 +596,15 @@ Pagination, below logRows
 	padding-bottom: 8px;
 }
 
-.SimpleHistoryPaginationLink.SimpleHistoryPaginationLink {
-	/*line-height: 30px;*/
-	/*background: rgb(238, 238, 238);*/
-	/*background: rgba(0, 0, 0, 0.05);*/
-	/*padding: 0 10px 3px;
-	text-decoration: none;*/
-	font-size: 16px;
-}
-
-.SimpleHistoryPaginationLink.SimpleHistoryPaginationLink:hover {
-	/*color: rgb(255, 255, 255);*/
-	/*background: rgb(46, 162, 204);*/
+.SimpleHistoryPaginationLinks .SimpleHistoryPaginationLink {
+    vertical-align: baseline;
+    min-width: 30px;
+    min-height: 30px;
+    margin: 0;
+    padding: 0 4px;
+    font-size: 16px;
+    line-height: 1.625;
+    text-align: center;
 }
 
 .SimpleHistoryPaginationLink.SimpleHistoryPaginationLink.disabled {
@@ -621,8 +615,13 @@ Pagination, below logRows
 }
 
 .SimpleHistoryPaginationCurrentPage {
-	/*padding-top: 0;*/
-	text-align: center;
+	margin: 0 2px 0 0;
+    font-size: 13px;
+    text-align: center;
+}
+
+.SimpleHistoryPaginationInput .total-pages {
+	margin-right: 2px;
 }
 
 /*


### PR DESCRIPTION
Hi. Thanks for merging this code. Only minor adjustments to match WordPress core pagination styles. We could not use the exact markup since the table nav wrapper element floats to the right and your buttons are center-aligned. 

Fixes for #200 