### PR TITLE
fix placeholder issue if text is too long

### DIFF
--- a/dropins/SimpleHistoryFilterDropin.css
+++ b/dropins/SimpleHistoryFilterDropin.css
@@ -22,7 +22,7 @@
 .SimpleHistory__filters__form input[type="text"],
 .SimpleHistory__filters__form input[type="search"] {
 	/* width: 100%; */
-	/* width: 310px; */
+	width: 310px !important;
 }
 
 .SimpleHistory__filters__filter--date,


### PR DESCRIPTION
There is a bug in select2 when the field is hidden : https://github.com/select2/select2/issues/3817

No problem in english but if the translation is longer : 

![image](https://user-images.githubusercontent.com/10757301/92370494-a6d9c000-f0fa-11ea-8591-0fa43646cc18.png)

This PR fixes the issue