### PR TITLE
Log changes to custom post type entry while using the Block Editor (Gutenberg)

### DIFF
--- a/inc/SimpleHistory.php
+++ b/inc/SimpleHistory.php
@@ -96,13 +96,13 @@ class SimpleHistory
         add_action('after_setup_theme', [$this, 'load_plugin_textdomain']);
         add_action('after_setup_theme', [$this, 'add_default_settings_tabs']);
 
-        // Plugins and dropins are loaded using the "init" filter so
+        // Plugins and dropins are loaded using the "after_setup_theme" filter so
         // themes and plugins can use filters to modify the loading of them.
         // The drawback with this is that for example logouts done when plugins like
         // iThemes Security is installed is not logged, because those plugins fire wp_logout()
         // using filter "plugins_loaded", i.e. before simple history has loaded its filters.
-        add_action('init', [$this, 'load_loggers'], 99);
-        add_action('init', [$this, 'load_dropins'], 99);
+        add_action('after_setup_theme', [$this, 'load_loggers']);
+        add_action('after_setup_theme', [$this, 'load_dropins']);
 
         // Run before loading of loggers and before menu items are added.
         add_action('after_setup_theme', [$this, 'check_for_upgrade'], 5);

--- a/inc/SimpleHistory.php
+++ b/inc/SimpleHistory.php
@@ -96,13 +96,13 @@ class SimpleHistory
         add_action('after_setup_theme', [$this, 'load_plugin_textdomain']);
         add_action('after_setup_theme', [$this, 'add_default_settings_tabs']);
 
-        // Plugins and dropins are loaded using the "after_setup_theme" filter so
-        // themes can use filters to modify the loading of them.
+        // Plugins and dropins are loaded using the "init" filter so
+        // themes and plugins can use filters to modify the loading of them.
         // The drawback with this is that for example logouts done when plugins like
         // iThemes Security is installed is not logged, because those plugins fire wp_logout()
         // using filter "plugins_loaded", i.e. before simple history has loaded its filters.
-        add_action('after_setup_theme', [$this, 'load_loggers']);
-        add_action('after_setup_theme', [$this, 'load_dropins']);
+        add_action('init', [$this, 'load_loggers'], 99);
+        add_action('init', [$this, 'load_dropins'], 99);
 
         // Run before loading of loggers and before menu items are added.
         add_action('after_setup_theme', [$this, 'check_for_upgrade'], 5);

--- a/inc/SimpleHistory.php
+++ b/inc/SimpleHistory.php
@@ -97,7 +97,7 @@ class SimpleHistory
         add_action('after_setup_theme', [$this, 'add_default_settings_tabs']);
 
         // Plugins and dropins are loaded using the "after_setup_theme" filter so
-        // themes and plugins can use filters to modify the loading of them.
+        // themes can use filters to modify the loading of them.
         // The drawback with this is that for example logouts done when plugins like
         // iThemes Security is installed is not logged, because those plugins fire wp_logout()
         // using filter "plugins_loaded", i.e. before simple history has loaded its filters.

--- a/loggers/SimplePostLogger.php
+++ b/loggers/SimplePostLogger.php
@@ -35,7 +35,7 @@ class SimplePostLogger extends SimpleLogger
         add_action('untrash_post', array($this, 'on_untrash_post'));
 
         $this->add_xml_rpc_hooks();
-        $this->add_rest_hooks();
+        add_action('init', array($this,'add_rest_hooks'),99);
 
         add_filter('simple_history/rss_item_link', array($this, 'filter_rss_item_link'), 10, 2);
     }

--- a/loggers/SimplePostLogger.php
+++ b/loggers/SimplePostLogger.php
@@ -45,22 +45,17 @@ class SimplePostLogger extends SimpleLogger
      */
     public function add_rest_hooks()
     {
-        // Get all post types so that we can use the block editor with custom post types.
-        $core                  = get_post_types([ '_builtin' => true ], 'object');
-        $public                = get_post_types([ '_builtin' => false, 'public' => true ], 'object');
-        $private               = get_post_types([ '_builtin' => false, 'public' => false ], 'object');
-        $registered_post_types = array_merge($core, $public, $private);
 
         /**
          * FIlter the post types we are logging information from.
          *
-         * @param array $registered_post_types Core, public and private post types.
+         * @param array $post_types Core, public and private post types.
          *
-         * @return array $registered_post_types Filtered post types.
+         * @return array $post_types Filtered post types.
          *
          * @since 2.37
          */
-        $post_types = apply_filters('simple_history/post_logger/post_types', $registered_post_types);
+        $post_types = apply_filters('simple_history/post_logger/post_types', get_post_types(array(), 'object'));
 
         // Add actions for each post type.
         foreach ($post_types as $post_type) {

--- a/loggers/SimplePostLogger.php
+++ b/loggers/SimplePostLogger.php
@@ -45,8 +45,22 @@ class SimplePostLogger extends SimpleLogger
      */
     public function add_rest_hooks()
     {
-        // Get all post types.
-        $post_types = get_post_types(array(), 'objects');
+        // Get all post types so that we can use the block editor with custom post types.
+        $core                  = get_post_types([ '_builtin' => true ], 'object');
+        $public                = get_post_types([ '_builtin' => false, 'public' => true ], 'object');
+        $private               = get_post_types([ '_builtin' => false, 'public' => false ], 'object');
+        $registered_post_types = array_merge($core, $public, $private);
+
+        /**
+         * FIlter the post types we are logging information from.
+         *
+         * @param array $registered_post_types Core, public and private post types.
+         *
+         * @return array $registered_post_types Filtered post types.
+         *
+         * @since 2.37
+         */
+        $post_types = apply_filters('simple_history/post_logger/post_types', $registered_post_types);
 
         // Add actions for each post type.
         foreach ($post_types as $post_type) {


### PR DESCRIPTION
The main goal of this PR is to log changes made to custom post type entries while using the Block Editor from #215 

This might be a breaking change.

Before these changes, I tested making a change to Posts, Pages, and a custom post type named Team. I was able to see changes from Post and Page but not from Team. I tested creating a custom post type with [Custom Post Type UI](https://wordpress.org/plugins/custom-post-type-ui/) as well as creating one from scratch with the code below. The one from scartch loads on `init` at priority 10. The one built with the plugin loads on `init` but I could not figure out at which prioirty. `show_in_rest` was enabled and I was able to find it in the wp-json response.

My first idea was to have the loggers and dropins loads at a priority of 10 as well but then the cpt made with the plugin did not get logged. That is why I moved it all the way to 99.

```
function cptui_register_my_cpts() {

    /**
     * Post Type: Teams.
     */

    $labels = [
        "name" => __( "Teams", "twentytwenty" ),
        "singular_name" => __( "Team", "twentytwenty" ),
    ];

    $args = [
        "label" => __( "Teams", "twentytwenty" ),
        "labels" => $labels,
        "description" => "",
        "public" => true,
        "publicly_queryable" => true,
        "show_ui" => true,
        "show_in_rest" => true,
        "rest_base" => "",
        "rest_controller_class" => "WP_REST_Posts_Controller",
        "has_archive" => false,
        "show_in_menu" => true,
        "show_in_nav_menus" => true,
        "delete_with_user" => false,
        "exclude_from_search" => false,
        "capability_type" => "post",
        "map_meta_cap" => true,
        "hierarchical" => false,
        "rewrite" => [ "slug" => "team", "with_front" => true ],
        "query_var" => true,
        "supports" => [ "title", "editor", "thumbnail" ],
    ];

    register_post_type( "team", $args );
}

add_action( 'init', 'cptui_register_my_cpts' );
```
