### PR TITLE
Introduce an integration for the WP Crontrol plugin

### DIFF
--- a/inc/SimpleHistory.php
+++ b/inc/SimpleHistory.php
@@ -896,6 +896,7 @@ class SimpleHistory
 
             // Loggers for third party plugins.
             $loggersDir . 'PluginUserSwitchingLogger.php',
+            $loggersDir . 'PluginWPCrontrolLogger.php',
             $loggersDir . 'PluginEnableMediaReplaceLogger.php',
             $loggersDir . 'Plugin_UltimateMembers_Logger.php',
             $loggersDir . 'Plugin_LimitLoginAttempts.php',

--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -28,6 +28,8 @@ class PluginWPCrontrolLogger extends SimpleLogger
             'capability' => 'manage_options',
             'messages' => array(
                 'added_new_event' => _x('Added cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
+                'added_new_php_event' => _x('Added PHP cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
+                'ran_event' => _x('Ran cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
             ),
         );
 
@@ -38,14 +40,15 @@ class PluginWPCrontrolLogger extends SimpleLogger
     {
 
         add_action('crontrol/added_new_event', array( $this, 'added_new_event' ));
-        // add_action('crontrol/added_new_php_event', array( $this, 'added_new_event' ));
+        add_action('crontrol/added_new_php_event', array( $this, 'added_new_event' ));
+        add_action('crontrol/ran_event', array( $this, 'ran_event' ));
     }
 
     /**
      * Fires when a new cron event is added.
      *
      * @param object $event {
-     *     An object containing an event's data.
+     *     An object containing the event's data.
      *
      *     @type string       $hook      Action hook to execute when the event is run.
      *     @type int          $timestamp Unix timestamp (UTC) for when to next run the event.
@@ -78,9 +81,33 @@ class PluginWPCrontrolLogger extends SimpleLogger
         );
     }
 
-    public function getLogRowDetailsOutput($row) {
-        // return '<pre>' . print_r($row,true) . '</pre>';
+    /**
+     * Fires when a cron event is ran manually.
+     *
+     * @param object $event {
+     *     An object containing the event's data.
+     *
+     *     @type string       $hook      Action hook to execute when the event is run.
+     *     @type int          $timestamp Unix timestamp (UTC) for when to next run the event.
+     *     @type string|false $schedule  How often the event should subsequently recur.
+     *     @type array        $args      Array containing each separate argument to pass to the hook's callback function.
+     *     @type int          $interval  The interval time in seconds for the schedule. Only present for recurring events.
+     * }
+     */
+    public function ran_event($event)
+    {
+        $context = array(
+            'event_hook' => $event->hook,
+            'event_args' => $event->args,
+        );
 
+        $this->infoMessage(
+            'ran_event',
+            $context
+        );
+    }
+
+    public function getLogRowDetailsOutput($row) {
         $tmpl_row = '
             <tr>
                 <td>%1$s</td>

--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -31,7 +31,7 @@ class PluginWPCrontrolLogger extends SimpleLogger
             'messages' => array(
                 'added_new_event' => _x('Added cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'added_new_php_event' => _x('Added PHP cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
-                'ran_event' => _x('Ran cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
+                'ran_event' => _x('Manually ran cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'deleted_event' => _x('Deleted cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
             ),
         );

--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -49,6 +49,7 @@ class PluginWPCrontrolLogger extends SimpleLogger
         add_action('crontrol/deleted_event', array( $this, 'deleted_event' ));
         add_action('crontrol/deleted_all_with_hook', array( $this, 'deleted_all_with_hook' ), 10, 2);
         add_action('crontrol/edited_event', array( $this, 'edited_event' ), 10, 2);
+        add_action('crontrol/edited_php_event', array( $this, 'edited_event' ), 10, 2);
     }
 
     /**

--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -6,6 +6,8 @@ defined('ABSPATH') or die();
  * Logs cron event management from the WP Crontrol plugin
  * Plugin URL: https://wordpress.org/plugins/wp-crontrol/
  *
+ * Requires WP Crontrol 1.9.0 or later.
+ *
  * @since x.x
  */
 class PluginWPCrontrolLogger extends SimpleLogger
@@ -30,6 +32,7 @@ class PluginWPCrontrolLogger extends SimpleLogger
                 'added_new_event' => _x('Added cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'added_new_php_event' => _x('Added PHP cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'ran_event' => _x('Ran cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
+                'deleted_event' => _x('Deleted cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
             ),
         );
 
@@ -42,6 +45,7 @@ class PluginWPCrontrolLogger extends SimpleLogger
         add_action('crontrol/added_new_event', array( $this, 'added_new_event' ));
         add_action('crontrol/added_new_php_event', array( $this, 'added_new_event' ));
         add_action('crontrol/ran_event', array( $this, 'ran_event' ));
+        add_action('crontrol/deleted_event', array( $this, 'deleted_event' ));
     }
 
     /**
@@ -103,6 +107,43 @@ class PluginWPCrontrolLogger extends SimpleLogger
 
         $this->infoMessage(
             'ran_event',
+            $context
+        );
+    }
+
+    /**
+     * Fires when a cron event is deleted.
+     *
+     * @param object $event {
+     *     An object containing the event's data.
+     *
+     *     @type string       $hook      Action hook to execute when the event is run.
+     *     @type int          $timestamp Unix timestamp (UTC) for when to next run the event.
+     *     @type string|false $schedule  How often the event should subsequently recur.
+     *     @type array        $args      Array containing each separate argument to pass to the hook's callback function.
+     *     @type int          $interval  The interval time in seconds for the schedule. Only present for recurring events.
+     * }
+     */
+    public function deleted_event($event)
+    {
+        $context = array(
+            'event_hook' => $event->hook,
+            'event_timestamp' => $event->timestamp,
+            'event_args' => $event->args,
+        );
+
+        if ( $event->schedule ) {
+            $context['event_schedule_name'] = $event->schedule;
+
+            if ( function_exists( '\Crontrol\Event\get_schedule_name' ) ) {
+                $context['event_schedule_name'] = \Crontrol\Event\get_schedule_name( $event );
+            }
+        } else {
+            $context['event_schedule_name'] = _x('None', 'PluginWPCrontrolLogger', 'simple-history');
+        }
+
+        $this->infoMessage(
+            'deleted_event',
             $context
         );
     }

--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -30,7 +30,6 @@ class PluginWPCrontrolLogger extends SimpleLogger
             'capability' => 'manage_options',
             'messages' => array(
                 'added_new_event' => _x('Added cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
-                'added_new_php_event' => _x('Added PHP cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'ran_event' => _x('Manually ran cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'deleted_event' => _x('Deleted cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'deleted_all_with_hook' => _x('Deleted all "{event_hook}" cron events', 'PluginWPCrontrolLogger', 'simple-history'),

--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -33,6 +33,7 @@ class PluginWPCrontrolLogger extends SimpleLogger
                 'added_new_php_event' => _x('Added PHP cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'ran_event' => _x('Manually ran cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
                 'deleted_event' => _x('Deleted cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
+                'deleted_all_with_hook' => _x('Deleted all "{event_hook}" cron events', 'PluginWPCrontrolLogger', 'simple-history'),
             ),
         );
 
@@ -46,10 +47,11 @@ class PluginWPCrontrolLogger extends SimpleLogger
         add_action('crontrol/added_new_php_event', array( $this, 'added_new_event' ));
         add_action('crontrol/ran_event', array( $this, 'ran_event' ));
         add_action('crontrol/deleted_event', array( $this, 'deleted_event' ));
+        add_action('crontrol/deleted_all_with_hook', array( $this, 'deleted_all_with_hook' ), 10, 2);
     }
 
     /**
-     * Fires when a new cron event is added.
+     * Fires after a new cron event is added.
      *
      * @param object $event {
      *     An object containing the event's data.
@@ -86,7 +88,7 @@ class PluginWPCrontrolLogger extends SimpleLogger
     }
 
     /**
-     * Fires when a cron event is ran manually.
+     * Fires after a cron event is ran manually.
      *
      * @param object $event {
      *     An object containing the event's data.
@@ -112,7 +114,7 @@ class PluginWPCrontrolLogger extends SimpleLogger
     }
 
     /**
-     * Fires when a cron event is deleted.
+     * Fires after a cron event is deleted.
      *
      * @param object $event {
      *     An object containing the event's data.
@@ -144,6 +146,25 @@ class PluginWPCrontrolLogger extends SimpleLogger
 
         $this->infoMessage(
             'deleted_event',
+            $context
+        );
+    }
+
+    /**
+     * Fires after all cron events with the given hook are deleted.
+     *
+     * @param string $hook    The hook name.
+     * @param int    $deleted The number of events that were deleted.
+     */
+    public function deleted_all_with_hook($hook, $deleted)
+    {
+        $context = array(
+            'event_hook' => $hook,
+            'events_deleted' => $deleted,
+        );
+
+        $this->infoMessage(
+            'deleted_all_with_hook',
             $context
         );
     }

--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -90,34 +90,34 @@ class PluginWPCrontrolLogger extends SimpleLogger
         $context = $row->context;
         $output = '<table class="SimpleHistoryLogitem__keyValueTable">';
 
-        switch ( $row->context_message_key ) {
-            case 'added_new_event':
-            case 'added_new_php_event':
-                if ( '[]' !== $context['event_args'] ) {
-                    $args = $context['event_args'];
-                } else {
-                    $args = _x('None', 'PluginWPCrontrolLogger', 'simple-history');
-                }
+        if ( isset( $context['event_args'] ) ) {
+            if ( '[]' !== $context['event_args'] ) {
+                $args = $context['event_args'];
+            } else {
+                $args = _x('None', 'PluginWPCrontrolLogger', 'simple-history');
+            }
 
-                $output .= sprintf(
-                    $tmpl_row,
-                    _x('Arguments', 'PluginWPCrontrolLogger', 'simple-history'),
-                    esc_html( $args )
-                );
+            $output .= sprintf(
+                $tmpl_row,
+                _x('Arguments', 'PluginWPCrontrolLogger', 'simple-history'),
+                esc_html( $args )
+            );
+        }
 
-                $output .= sprintf(
-                    $tmpl_row,
-                    _x('Next Run', 'PluginWPCrontrolLogger', 'simple-history'),
-                    esc_html( gmdate( 'Y-m-d H:i:s', $context['event_timestamp'] ) . ' UTC' )
-                );
+        if ( isset( $context['event_timestamp'] ) ) {
+            $output .= sprintf(
+                $tmpl_row,
+                _x('Next Run', 'PluginWPCrontrolLogger', 'simple-history'),
+                esc_html( gmdate( 'Y-m-d H:i:s', $context['event_timestamp'] ) . ' UTC' )
+            );
+        }
 
-                $output .= sprintf(
-                    $tmpl_row,
-                    _x('Recurrence', 'PluginWPCrontrolLogger', 'simple-history'),
-                    esc_html( $context['event_schedule_name'] )
-                );
-
-                break;
+        if ( isset( $context['event_schedule_name'] ) ) {
+            $output .= sprintf(
+                $tmpl_row,
+                _x('Recurrence', 'PluginWPCrontrolLogger', 'simple-history'),
+                esc_html( $context['event_schedule_name'] )
+            );
         }
 
         $output .= '</table>';

--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -1,0 +1,127 @@
+<?php
+
+defined('ABSPATH') or die();
+
+/**
+ * Logs cron event management from the WP Crontrol plugin
+ * Plugin URL: https://wordpress.org/plugins/wp-crontrol/
+ *
+ * @since x.x
+ */
+class PluginWPCrontrolLogger extends SimpleLogger
+{
+
+    public $slug = __CLASS__;
+
+    /**
+     * Get array with information about this logger
+     *
+     * @return array
+     */
+    public function getInfo()
+    {
+
+        $arr_info = array(
+            'name' => _x('WP Crontrol Logger', 'PluginWPCrontrolLogger', 'simple-history'),
+            'description' => _x('Logs management of cron events', 'PluginWPCrontrolLogger', 'simple-history'),
+            'name_via' => _x('Using plugin WP Crontrol', 'PluginWPCrontrolLogger', 'simple-history'),
+            'capability' => 'manage_options',
+            'messages' => array(
+                'added_new_event' => _x('Added cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history'),
+            ),
+        );
+
+        return $arr_info;
+    }
+
+    public function loaded()
+    {
+
+        add_action('crontrol/added_new_event', array( $this, 'added_new_event' ));
+        // add_action('crontrol/added_new_php_event', array( $this, 'added_new_event' ));
+    }
+
+    /**
+     * Fires when a new cron event is added.
+     *
+     * @param object $event {
+     *     An object containing an event's data.
+     *
+     *     @type string       $hook      Action hook to execute when the event is run.
+     *     @type int          $timestamp Unix timestamp (UTC) for when to next run the event.
+     *     @type string|false $schedule  How often the event should subsequently recur.
+     *     @type array        $args      Array containing each separate argument to pass to the hook's callback function.
+     *     @type int          $interval  The interval time in seconds for the schedule. Only present for recurring events.
+     * }
+     */
+    public function added_new_event($event)
+    {
+        $context = array(
+            'event_hook' => $event->hook,
+            'event_timestamp' => $event->timestamp,
+            'event_args' => $event->args,
+        );
+
+        if ( $event->schedule ) {
+            $context['event_schedule_name'] = $event->schedule;
+
+            if ( function_exists( '\Crontrol\Event\get_schedule_name' ) ) {
+                $context['event_schedule_name'] = \Crontrol\Event\get_schedule_name( $event );
+            }
+        } else {
+            $context['event_schedule_name'] = _x('None', 'PluginWPCrontrolLogger', 'simple-history');
+        }
+
+        $this->infoMessage(
+            'added_new_event',
+            $context
+        );
+    }
+
+    public function getLogRowDetailsOutput($row) {
+        // return '<pre>' . print_r($row,true) . '</pre>';
+
+        $tmpl_row = '
+            <tr>
+                <td>%1$s</td>
+                <td>%2$s</td>
+            </tr>
+        ';
+        $context = $row->context;
+        $output = '<table class="SimpleHistoryLogitem__keyValueTable">';
+
+        switch ( $row->context_message_key ) {
+            case 'added_new_event':
+            case 'added_new_php_event':
+                if ( '[]' !== $context['event_args'] ) {
+                    $args = $context['event_args'];
+                } else {
+                    $args = _x('None', 'PluginWPCrontrolLogger', 'simple-history');
+                }
+
+                $output .= sprintf(
+                    $tmpl_row,
+                    _x('Arguments', 'PluginWPCrontrolLogger', 'simple-history'),
+                    esc_html( $args )
+                );
+
+                $output .= sprintf(
+                    $tmpl_row,
+                    _x('Next Run', 'PluginWPCrontrolLogger', 'simple-history'),
+                    esc_html( gmdate( 'Y-m-d H:i:s', $context['event_timestamp'] ) . ' UTC' )
+                );
+
+                $output .= sprintf(
+                    $tmpl_row,
+                    _x('Recurrence', 'PluginWPCrontrolLogger', 'simple-history'),
+                    esc_html( $context['event_schedule_name'] )
+                );
+
+                break;
+        }
+
+        $output .= '</table>';
+
+        return $output;
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -63,8 +63,8 @@ The [User Switching plugin](https://wordpress.org/plugins/user-switching/) allow
 Simple History will log each user switch being made.
 
 **WP Crontrol**<br>
-The [WP Crontrol plugin](https://wordpress.org/plugins/wp-crontrol/) lets you view and control what's happening in the WP-Cron system.
-Simple History will log when cron events are added, edited, deleted, and manually ran.
+The [WP Crontrol plugin](https://wordpress.org/plugins/wp-crontrol/) enables you to view and control what's happening in the WP-Cron system.
+Simple History will log when cron events are added, edited, deleted, and manually ran, and when cron schedules are added and deleted.
 
 **Enable Media Replace**<br>
 The [Enable Media Replace plugin](https://wordpress.org/plugins/enable-media-replace/) allows you to replace a file in your media library by uploading a new file in its place.

--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,10 @@ Simple History will log changes made to the field groups and the fields inside f
 The [User Switching plugin](https://wordpress.org/plugins/user-switching/) allows you to quickly swap between user accounts in WordPress at the click of a button.
 Simple History will log each user switch being made.
 
+**WP Crontrol**<br>
+The [WP Crontrol plugin](https://wordpress.org/plugins/wp-crontrol/) lets you view and control what's happening in the WP-Cron system.
+Simple History will log when cron events are added, edited, deleted, and manually ran.
+
 **Enable Media Replace**<br>
 The [Enable Media Replace plugin](https://wordpress.org/plugins/enable-media-replace/) allows you to replace a file in your media library by uploading a new file in its place.
 Simple history will log details about the file being replaced and details about the new file.


### PR DESCRIPTION
This adds support for logging the following events that a user can perform via [the WP Crontrol plugin](https://wordpress.org/plugins/wp-crontrol/):

* Adding a cron event
* Editing a cron event
* Deleting an individual cron event
* Bulk deleting cron events
* Deleting all cron events with a given hook name
* Adding a cron schedule
* Deleting a cron schedule

This requires WP Crontrol version 1.9.0 or later.

## Screenshots

<img width="1078" alt="Screenshot 2020-12-30 at 19 35 41" src="https://user-images.githubusercontent.com/208434/103383350-b7bba080-4af2-11eb-9b6e-8507a1570396.png">
<img width="525" alt="Screenshot 2020-12-30 at 19 35 59" src="https://user-images.githubusercontent.com/208434/103383360-c2763580-4af2-11eb-99d3-9cddb93fdb51.png">
<img width="490" alt="Screenshot 2020-12-30 at 19 36 05" src="https://user-images.githubusercontent.com/208434/103383372-ca35da00-4af2-11eb-981d-6bc11c8be4b8.png">
<img width="487" alt="Screenshot 2020-12-30 at 19 36 19" src="https://user-images.githubusercontent.com/208434/103383385-d6219c00-4af2-11eb-9c47-a74eea806004.png">
<img width="460" alt="Screenshot 2020-12-30 at 20 29 57" src="https://user-images.githubusercontent.com/208434/103383387-d752c900-4af2-11eb-9a10-49dbf40a9125.png">
