### PR TITLE
array_map and reset cause warning in PHP 8

### DIFF
--- a/loggers/Plugin_ACF.php
+++ b/loggers/Plugin_ACF.php
@@ -204,7 +204,7 @@ if (! class_exists('Plugin_ACF')) {
 
             $new_post_meta = get_post_custom($post_id);
             array_walk($new_post_meta, function(&$value, $key){
-				$value = reset($value);
+			    $value = reset($value);
             });
 
             // New and old post meta can contain different amount of keys,
@@ -529,7 +529,7 @@ if (! class_exists('Plugin_ACF')) {
 
             // Meta is array of arrays, get first value of each array value.
             array_walk($post_meta, function(&$value, $key){
-				$value = reset($value);
+			    $value = reset($value);
             });
 
             $this->oldPostData['prev_post_meta'] = $post_meta;

--- a/loggers/Plugin_ACF.php
+++ b/loggers/Plugin_ACF.php
@@ -205,7 +205,7 @@ if (! class_exists('Plugin_ACF')) {
             $new_post_meta = get_post_custom($post_id);
             array_walk($new_post_meta, function(&$value, $key){
 				$value = reset($value);
-			});
+            });
 
             // New and old post meta can contain different amount of keys,
             // join them so we have the name of all post meta thaf have been added, removed, or modified.
@@ -530,7 +530,7 @@ if (! class_exists('Plugin_ACF')) {
             // Meta is array of arrays, get first value of each array value.
             array_walk($post_meta, function(&$value, $key){
 				$value = reset($value);
-			});
+            });
 
             $this->oldPostData['prev_post_meta'] = $post_meta;
         }

--- a/loggers/Plugin_ACF.php
+++ b/loggers/Plugin_ACF.php
@@ -203,7 +203,9 @@ if (! class_exists('Plugin_ACF')) {
             $prev_post_meta = isset($this->oldPostData['prev_post_meta']) ? $this->oldPostData['prev_post_meta'] : array();
 
             $new_post_meta = get_post_custom($post_id);
-            $new_post_meta = array_map('reset', $new_post_meta);
+            array_walk($new_post_meta, function(&$value, $key){
+				$value = reset($value);
+			});
 
             // New and old post meta can contain different amount of keys,
             // join them so we have the name of all post meta thaf have been added, removed, or modified.
@@ -526,7 +528,9 @@ if (! class_exists('Plugin_ACF')) {
             $post_meta = get_post_custom($post_ID);
 
             // Meta is array of arrays, get first value of each array value.
-            $post_meta = array_map('reset', $post_meta);
+            array_walk($post_meta, function(&$value, $key){
+				$value = reset($value);
+			});
 
             $this->oldPostData['prev_post_meta'] = $post_meta;
         }


### PR DESCRIPTION
Updated the 2 array_map-reset lines with a compatible version of array_walk. Was getting a warning that array_map isn't passing reset() the array by reference, only by value. The code still worked without the change but who knows in the future. Compared the output of the new array with the old one and they seems to match.