### PR TITLE
Fix translation comment

### DIFF
--- a/dropins/SimpleHistoryFilterDropin.php
+++ b/dropins/SimpleHistoryFilterDropin.php
@@ -631,9 +631,9 @@ class SimpleHistoryFilterDropin {
 			),
 		);
 
-		/* translators: 1: month, 2: day, 3: year */
 		echo wp_kses(
 			sprintf(
+				/* translators: 1: month, 2: day, 3: year */
 				__( '%1$s %2$s, %3$s', 'simple-history' ),
 				$month,
 				$day,


### PR DESCRIPTION
Apparently translate.wordpress.org ignores the comment if it is before the function : https://translate.wordpress.org/projects/wp-plugins/simple-history/stable/fr/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=3214722&filters%5Btranslation_id%5D=49828769

This patch should be fix the issue.