### PR TITLE
Log an entry when a cron event hook is paused or resumed with the WP Crontrol plugin

### DIFF
--- a/loggers/PluginWPCrontrolLogger.php
+++ b/loggers/PluginWPCrontrolLogger.php
@@ -32,6 +32,8 @@ class PluginWPCrontrolLogger extends SimpleLogger {
 				'ran_event'             => _x( 'Manually ran cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history' ),
 				'deleted_event'         => _x( 'Deleted cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history' ),
 				'deleted_all_with_hook' => _x( 'Deleted all "{event_hook}" cron events', 'PluginWPCrontrolLogger', 'simple-history' ),
+				'paused_hook'           => _x( 'Paused the "{event_hook}" cron event hook', 'PluginWPCrontrolLogger', 'simple-history' ),
+				'resumed_hook'          => _x( 'Resumed the "{event_hook}" cron event hook', 'PluginWPCrontrolLogger', 'simple-history' ),
 				'edited_event'          => _x( 'Edited cron event "{event_hook}"', 'PluginWPCrontrolLogger', 'simple-history' ),
 				'added_new_schedule'    => _x( 'Added cron schedule "{schedule_name}"', 'PluginWPCrontrolLogger', 'simple-history' ),
 				'deleted_schedule'      => _x( 'Deleted cron schedule "{schedule_name}"', 'PluginWPCrontrolLogger', 'simple-history' ),
@@ -48,6 +50,8 @@ class PluginWPCrontrolLogger extends SimpleLogger {
 		add_action( 'crontrol/ran_event', array( $this, 'ran_event' ) );
 		add_action( 'crontrol/deleted_event', array( $this, 'deleted_event' ) );
 		add_action( 'crontrol/deleted_all_with_hook', array( $this, 'deleted_all_with_hook' ), 10, 2 );
+		add_action( 'crontrol/paused_hook', array( $this, 'paused_hook' ) );
+		add_action( 'crontrol/resumed_hook', array( $this, 'resumed_hook' ) );
 		add_action( 'crontrol/edited_event', array( $this, 'edited_event' ), 10, 2 );
 		add_action( 'crontrol/edited_php_event', array( $this, 'edited_event' ), 10, 2 );
 		add_action( 'crontrol/added_new_schedule', array( $this, 'added_new_schedule' ), 10, 3 );
@@ -165,6 +169,38 @@ class PluginWPCrontrolLogger extends SimpleLogger {
 
 		$this->infoMessage(
 			'deleted_all_with_hook',
+			$context
+		);
+	}
+
+	/**
+	 * Fires after a cron event hook is paused.
+	 *
+	 * @param string $hook The hook name.
+	 */
+	public function paused_hook( $hook ) {
+		$context = array(
+			'event_hook' => $hook,
+		);
+
+		$this->infoMessage(
+			'paused_hook',
+			$context
+		);
+	}
+
+	/**
+	 * Fires after a cron event hook is resumed (unpaused).
+	 *
+	 * @param string $hook The hook name.
+	 */
+	public function resumed_hook( $hook ) {
+		$context = array(
+			'event_hook' => $hook,
+		);
+
+		$this->infoMessage(
+			'resumed_hook',
 			$context
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ Simple History will log each user switch being made.
 
 **WP Crontrol**<br>
 The [WP Crontrol plugin](https://wordpress.org/plugins/wp-crontrol/) enables you to view and control what's happening in the WP-Cron system.
-Simple History will log when cron events are added, edited, deleted, and manually ran, and when cron schedules are added and deleted.
+Simple History will log when cron events are added, edited, deleted, paused, resumed, and manually ran, and when cron schedules are added and deleted.
 
 **Enable Media Replace**<br>
 The [Enable Media Replace plugin](https://wordpress.org/plugins/enable-media-replace/) allows you to replace a file in your media library by uploading a new file in its place.


### PR DESCRIPTION
Since version 1.15, [the WP Crontrol plugin](https://wordpress.org/plugins/wp-crontrol/) allows you to pause and resume cron event hooks. This change adds a log entry in those situations.

## Screenshot

<img width="598" alt="" src="https://user-images.githubusercontent.com/208434/227189037-eadee81e-c57d-4d63-be46-f63c2db76827.png">
