### PR TITLE
Issue 488 incorrect time display in simple history log

### DIFF
--- a/inc/class-wp-rest-events-controller.php
+++ b/inc/class-wp-rest-events-controller.php
@@ -680,13 +680,17 @@ class WP_REST_Events_Controller extends WP_REST_Controller {
 			$data['id'] = (int) $item->id;
 		}
 
+		// date is the GTM date when the event was created.
+		// So on my local computer with timezone stockholm an event was added when my computer
+		// said "21 nov 2024 16:25" and the date in the
+		// database is "2024-11-21 15:24:00".
 		if ( rest_is_field_included( 'date', $fields ) ) {
-			$data['date'] = mysql_to_rfc3339( $item->date );
+			// Given a date in UTC or GMT timezone, returns that date in the timezone of the site.
+			$data['date'] = get_date_from_gmt( $item->date );
 		}
 
 		if ( rest_is_field_included( 'date_gmt', $fields ) ) {
-			// HERE: This does not look good. Wrong item field and strange function calls.
-			$data['date_gmt'] = mysql_to_rfc3339( get_date_from_gmt( mysql_to_rfc3339( $item->date ) ) );
+			$data['date_gmt'] = $item->date;
 		}
 
 		if ( rest_is_field_included( 'via', $fields ) ) {

--- a/inc/class-wp-rest-events-controller.php
+++ b/inc/class-wp-rest-events-controller.php
@@ -395,7 +395,7 @@ class WP_REST_Events_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'enum'        => array( 'overview', 'occasions' ),
 				),
-				'date'         => array(
+				'date_local'         => array(
 					'description' => __( "The date the event was added, in the site's timezone.", 'simple-history' ),
 					'type'        => array( 'string', 'null' ),
 					'format'      => 'date-time',
@@ -680,13 +680,13 @@ class WP_REST_Events_Controller extends WP_REST_Controller {
 			$data['id'] = (int) $item->id;
 		}
 
-		// date is the GTM date when the event was created.
+		// `date` column in database is the GTM date when the event was created.
 		// So on my local computer with timezone stockholm an event was added when my computer
 		// said "21 nov 2024 16:25" and the date in the
 		// database is "2024-11-21 15:24:00".
-		if ( rest_is_field_included( 'date', $fields ) ) {
+		if ( rest_is_field_included( 'date_local', $fields ) ) {
 			// Given a date in UTC or GMT timezone, returns that date in the timezone of the site.
-			$data['date'] = get_date_from_gmt( $item->date );
+			$data['date_local'] = get_date_from_gmt( $item->date );
 		}
 
 		if ( rest_is_field_included( 'date_gmt', $fields ) ) {

--- a/inc/class-wp-rest-events-controller.php
+++ b/inc/class-wp-rest-events-controller.php
@@ -685,6 +685,7 @@ class WP_REST_Events_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'date_gmt', $fields ) ) {
+			// HERE: This does not look good. Wrong item field and strange function calls.
 			$data['date_gmt'] = mysql_to_rfc3339( get_date_from_gmt( mysql_to_rfc3339( $item->date ) ) );
 		}
 

--- a/loggers/class-logger.php
+++ b/loggers/class-logger.php
@@ -1206,9 +1206,9 @@ abstract class Logger {
 		 * Store date as GMT date, i.e. not local date/time
 		 *
 		 * @see http://www.skyverge.com/blog/down-the-rabbit-hole-wordpress-and-timezones/
-		 * @string $localtime
+		 * @var string $date_gmt Date in GMT format.
 		 */
-		$localtime = current_time( 'mysql', 1 );
+		$date_gmt = current_time( 'mysql', 1 );
 
 		/**
 		 * Main table data row array.
@@ -1218,7 +1218,7 @@ abstract class Logger {
 		$data = array(
 			'logger' => $this->get_slug(),
 			'level' => $level,
-			'date' => $localtime,
+			'date' => $date_gmt,
 			'message' => $message,
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -276,8 +276,11 @@ Read more at the [FAQ on the plugin website](https://simple-history.com/docs/faq
 ### Unreleased
 
 -   Split the event date and time tooltip into two lines.
-
+-   Use correct date fields from API response in the GUI datetime tooltip.
 -   Include date_gmt in event context modal.
+-   Date field in REST API response is not rename to date_local, to make it more clear that it's the website local date and time of the event.
+-   Append website timezone to datetime tooltip.
+
 ### 5.2.0 (November 2024)
 
 Some minor bugfixes but also a new feature in this update. [Read the release post for more info](https://simple-history.com/2024/simple-history-5-2-0-released/).

--- a/readme.txt
+++ b/readme.txt
@@ -275,11 +275,12 @@ Read more at the [FAQ on the plugin website](https://simple-history.com/docs/faq
 
 ### Unreleased
 
+-   The time of each event is now shown in the user's local time zone, as reported by the web browser. This makes it easier to understand when an event happened for users in different time zones.
 -   Split the event date and time tooltip into two lines.
 -   Use correct date fields from API response in the GUI datetime tooltip.
 -   Include date_gmt in event context modal.
--   Date field in REST API response is not rename to date_local, to make it more clear that it's the website local date and time of the event.
--   Append website timezone to datetime tooltip.
+-   Date field in REST API response is now rename to date_local, to make it more clear that it's the website local date and time of the event.
+-   Show more information about the event date and time in the datetime tooltip.
 
 ### 5.2.0 (November 2024)
 

--- a/readme.txt
+++ b/readme.txt
@@ -273,6 +273,9 @@ Read more at the [FAQ on the plugin website](https://simple-history.com/docs/faq
 [Then sponsor the plugin to keep it free](https://simple-history.com/sponsor/) or
 [add a 5-star review so other users know it's good](https://wordpress.org/support/plugin/simple-history/reviews/?filter=5).
 
+### Unreleased
+
+-   Include date_gmt in event context modal.
 ### 5.2.0 (November 2024)
 
 Some minor bugfixes but also a new feature in this update. [Read the release post for more info](https://simple-history.com/2024/simple-history-5-2-0-released/).

--- a/readme.txt
+++ b/readme.txt
@@ -275,6 +275,8 @@ Read more at the [FAQ on the plugin website](https://simple-history.com/docs/faq
 
 ### Unreleased
 
+-   Split the event date and time tooltip into two lines.
+
 -   Include date_gmt in event context modal.
 ### 5.2.0 (November 2024)
 

--- a/src/components/EventDate.jsx
+++ b/src/components/EventDate.jsx
@@ -22,15 +22,13 @@ export function EventDate( props ) {
 	const wpTimezoneString = dateSettings.timezone.string;
 	const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 	const eventDateTimeInGMTTimeZone = event.date_gmt + '+0000';
-
-	// Show date as "Sep 2, 2024 8:36 pm".
-	// If the event is today, show "Today instead".
-	// Today is determined by the date in GMT.
 	const eventDateYMD = date( 'Y-m-d', eventDateTimeInGMTTimeZone );
 	const eventIsToday = eventDateYMD === date( 'Y-m-d', undefined, 'GMT' );
 
 	let formattedDateFormatAbbreviated;
 
+	// Show date as "Sep 2, 2024 8:36 pm".
+	// If the event is today, show "Today H:i" instead.
 	if ( eventIsToday ) {
 		formattedDateFormatAbbreviated = sprintf(
 			// translators: %s is the time, like 8:36 pm.

--- a/src/components/EventDate.jsx
+++ b/src/components/EventDate.jsx
@@ -60,10 +60,11 @@ export function EventDate( props ) {
 
 	const tooltipText = (
 		<>
-			{
+			{ sprintf(
 				/* translators: 1: date in local time */
-				sprintf( __( `%1$s local time`, 'simple-history' ), event.date )
-			}
+				__( `%1$s website local time`, 'simple-history' ),
+				event.date
+			) }
 			<br />
 			{ sprintf(
 				/* translators: 1: date in GMT time */

--- a/src/components/EventDate.jsx
+++ b/src/components/EventDate.jsx
@@ -4,10 +4,10 @@ import {
 	Tooltip,
 } from '@wordpress/components';
 import {
+	date,
 	dateI18n,
 	getSettings as getDateSettings,
 	humanTimeDiff,
-	date,
 } from '@wordpress/date';
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -17,28 +17,35 @@ import { EventHeaderItem } from './EventHeaderItem';
 export function EventDate( props ) {
 	const { event, eventVariant } = props;
 	const dateSettings = getDateSettings();
-	const dateFormatAbbreviated = dateSettings.formats.datetimeAbbreviated;
-	const dateFormatTime = dateSettings.formats.time;
-	const timezoneString = dateSettings.timezone.string;
+	const wpDateFormatAbbreviated = dateSettings.formats.datetimeAbbreviated;
+	const wpDateFormatTime = dateSettings.formats.time;
+	const wpTimezoneString = dateSettings.timezone.string;
+	const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	const eventDateTimeInGMTTimeZone = event.date_gmt + '+0000';
 
 	// Show date as "Sep 2, 2024 8:36 pm".
 	// If the event is today, show "Today instead".
 	// Today is determined by the date in GMT.
-	const eventDateYMD = date( 'Y-m-d', event.date_local );
-	const nowDateYMD = date( 'Y-m-d' );
-	const eventIsToday = eventDateYMD === nowDateYMD;
+	const eventDateYMD = date( 'Y-m-d', eventDateTimeInGMTTimeZone );
+	const eventIsToday = eventDateYMD === date( 'Y-m-d', undefined, 'GMT' );
 
 	let formattedDateFormatAbbreviated;
+
 	if ( eventIsToday ) {
 		formattedDateFormatAbbreviated = sprintf(
 			// translators: %s is the time, like 8:36 pm.
 			__( 'Today %s', 'simple-history' ),
-			dateI18n( dateFormatTime, event.date_local )
+			dateI18n(
+				wpDateFormatTime,
+				eventDateTimeInGMTTimeZone,
+				browserTimeZone
+			)
 		);
 	} else {
 		formattedDateFormatAbbreviated = dateI18n(
-			dateFormatAbbreviated,
-			event.date_local
+			wpDateFormatAbbreviated,
+			eventDateTimeInGMTTimeZone,
+			browserTimeZone
 		);
 	}
 
@@ -61,18 +68,57 @@ export function EventDate( props ) {
 
 	const tooltipText = (
 		<>
-			{ sprintf(
-				/* translators: 1: date in local time, 2: timezone string */
-				__( `%1$s website local time (%2$s)`, 'simple-history' ),
-				event.date_local,
-				timezoneString
-			) }
-			<br />
-			{ sprintf(
-				/* translators: 1: date in GMT time */
-				__( `%1$s GMT time`, 'simple-history' ),
-				event.date_gmt
-			) }
+			<table>
+				<thead>
+					<tr>
+						<th>Date</th>
+						<th>Description</th>
+					</tr>
+				</thead>
+
+				<tbody>
+					<tr>
+						<td>{ event.date_gmt }</td>
+						<td>{ __( `GMT time`, 'simple-history' ) }</td>
+					</tr>
+
+					<tr>
+						<td>{ event.date_local }</td>
+						<td>
+							{ sprintf(
+								/* translators: 1: timezone string */
+								__(
+									`Website timezone (%1$s)`,
+									'simple-history'
+								),
+								wpTimezoneString
+							) }
+						</td>
+					</tr>
+
+					{ wpTimezoneString !== browserTimeZone && (
+						<tr>
+							<td>
+								{ dateI18n(
+									'Y-m-d H:i:s',
+									eventDateTimeInGMTTimeZone,
+									browserTimeZone
+								) }
+							</td>
+							<td>
+								{ sprintf(
+									/* translators: 1: browser timezone */
+									__(
+										`Browser local time (%1$s)`,
+										'simple-history'
+									),
+									browserTimeZone
+								) }
+							</td>
+						</tr>
+					) }
+				</tbody>
+			</table>
 		</>
 	);
 

--- a/src/components/EventDate.jsx
+++ b/src/components/EventDate.jsx
@@ -19,6 +19,7 @@ export function EventDate( props ) {
 	const dateSettings = getDateSettings();
 	const dateFormatAbbreviated = dateSettings.formats.datetimeAbbreviated;
 	const dateFormatTime = dateSettings.formats.time;
+	const timezoneString = dateSettings.timezone.string;
 
 	// Show date as "Sep 2, 2024 8:36 pm".
 	// If the event is today, show "Today instead".
@@ -61,9 +62,10 @@ export function EventDate( props ) {
 	const tooltipText = (
 		<>
 			{ sprintf(
-				/* translators: 1: date in local time */
-				__( `%1$s website local time`, 'simple-history' ),
-				event.date
+				/* translators: 1: date in local time, 2: timezone string */
+				__( `%1$s website local time (%2$s)`, 'simple-history' ),
+				event.date,
+				timezoneString
 			) }
 			<br />
 			{ sprintf(

--- a/src/components/EventDate.jsx
+++ b/src/components/EventDate.jsx
@@ -58,11 +58,19 @@ export function EventDate( props ) {
 		};
 	}, [ event.date_gmt ] );
 
-	const tooltipText = sprintf(
-		/* translators: 1: date in local time, 2: date in GMT time */
-		__( '%1$s local time (%2$s GMT time)', 'simple-history' ),
-		event.date,
-		event.date_gmt
+	const tooltipText = (
+		<>
+			{
+				/* translators: 1: date in local time */
+				sprintf( __( `%1$s local time`, 'simple-history' ), event.date )
+			}
+			<br />
+			{ sprintf(
+				/* translators: 1: date in GMT time */
+				__( `%1$s GMT time`, 'simple-history' ),
+				event.date_gmt
+			) }
+		</>
 	);
 
 	const handleDateClick = () => {
@@ -70,15 +78,12 @@ export function EventDate( props ) {
 	};
 
 	const time = (
-		<>
-			<time
-				dateTime={ event.date_gmt }
-				className="SimpleHistoryLogitem__when__liveRelative"
-			>
-				{ formattedDateFormatAbbreviated } ({ formattedDateLiveUpdated }
-				)
-			</time>
-		</>
+		<time
+			dateTime={ event.date_gmt }
+			className="SimpleHistoryLogitem__when__liveRelative"
+		>
+			{ formattedDateFormatAbbreviated } ({ formattedDateLiveUpdated })
+		</time>
 	);
 
 	let output;

--- a/src/components/EventDate.jsx
+++ b/src/components/EventDate.jsx
@@ -24,7 +24,7 @@ export function EventDate( props ) {
 	// Show date as "Sep 2, 2024 8:36 pm".
 	// If the event is today, show "Today instead".
 	// Today is determined by the date in GMT.
-	const eventDateYMD = date( 'Y-m-d', event.date_gmt );
+	const eventDateYMD = date( 'Y-m-d', event.date_local );
 	const nowDateYMD = date( 'Y-m-d' );
 	const eventIsToday = eventDateYMD === nowDateYMD;
 
@@ -33,31 +33,31 @@ export function EventDate( props ) {
 		formattedDateFormatAbbreviated = sprintf(
 			// translators: %s is the time, like 8:36 pm.
 			__( 'Today %s', 'simple-history' ),
-			dateI18n( dateFormatTime, event.date_gmt )
+			dateI18n( dateFormatTime, event.date_local )
 		);
 	} else {
 		formattedDateFormatAbbreviated = dateI18n(
 			dateFormatAbbreviated,
-			event.date_gmt
+			event.date_local
 		);
 	}
 
 	const [ formattedDateLiveUpdated, setFormattedDateLiveUpdated ] = useState(
 		() => {
-			return humanTimeDiff( event.date_gmt );
+			return humanTimeDiff( event.date_local );
 		}
 	);
 
 	// Update live time every second.
 	useEffect( () => {
 		const intervalId = setInterval( () => {
-			setFormattedDateLiveUpdated( humanTimeDiff( event.date_gmt ) );
+			setFormattedDateLiveUpdated( humanTimeDiff( event.date_local ) );
 		}, 1000 );
 
 		return () => {
 			clearInterval( intervalId );
 		};
-	}, [ event.date_gmt ] );
+	}, [ event.date_local ] );
 
 	const tooltipText = (
 		<>

--- a/src/components/EventDate.jsx
+++ b/src/components/EventDate.jsx
@@ -64,7 +64,7 @@ export function EventDate( props ) {
 			{ sprintf(
 				/* translators: 1: date in local time, 2: timezone string */
 				__( `%1$s website local time (%2$s)`, 'simple-history' ),
-				event.date,
+				event.date_local,
 				timezoneString
 			) }
 			<br />

--- a/src/components/EventInfoModal.jsx
+++ b/src/components/EventInfoModal.jsx
@@ -107,6 +107,10 @@ export function EventInfoModal( props ) {
 									<td>{ loadedEvent.date }</td>
 								</tr>
 								<tr>
+									<td>date_gmt</td>
+									<td>{ loadedEvent.date_gmt }</td>
+								</tr>
+								<tr>
 									<td>message</td>
 									<td>{ loadedEvent.message }</td>
 								</tr>

--- a/src/components/EventInfoModal.jsx
+++ b/src/components/EventInfoModal.jsx
@@ -31,7 +31,7 @@ export function EventInfoModal( props ) {
 					'details_data',
 					'details_html',
 					'message_uninterpolated',
-					'date',
+					'date_local',
 					'date_gmt',
 					'message',
 					'context',
@@ -103,8 +103,8 @@ export function EventInfoModal( props ) {
 									<td>{ loadedEvent.loglevel }</td>
 								</tr>
 								<tr>
-									<td>date</td>
-									<td>{ loadedEvent.date }</td>
+									<td>date_local</td>
+									<td>{ loadedEvent.date_local }</td>
 								</tr>
 								<tr>
 									<td>date_gmt</td>

--- a/src/components/EventOccasions.jsx
+++ b/src/components/EventOccasions.jsx
@@ -86,7 +86,7 @@ export function EventOccasions( props ) {
 			per_page: 5,
 			_fields: [
 				'id',
-				'date',
+				'date_local',
 				'date_gmt',
 				'message',
 				'message_html',

--- a/src/functions.js
+++ b/src/functions.js
@@ -33,7 +33,7 @@ export function generateAPIQueryParams( props ) {
 		_fields: [
 			'id',
 			'logger',
-			'date',
+			'date_local',
 			'date_gmt',
 			'message',
 			'message_html',


### PR DESCRIPTION
This PR changes the display of the date and time of each event in the feed to display the time using the users current timezone (as reported by the web browser).

This change should make the log easier to read and understand for users that work in a timezone that differs from the timezone of the wordpress website.