### PR TITLE
Fix php notice when logging found plugin updates if another plugin used an invalid plugin slug (e.g., "myplugin" instead of "myplugin/myplugin.php")

### DIFF
--- a/loggers/class-available-updates-logger.php
+++ b/loggers/class-available-updates-logger.php
@@ -142,7 +142,7 @@ class Available_Updates_Logger extends Logger {
 			$file = WP_PLUGIN_DIR . '/' . $key;
 
 			// Continue with next plugin if plugin file did not exist.
-			if ( ! file_exists( $file ) ) {
+			if ( ! is_file( $file ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Logged notice:
```
PHP Notice:  file_get_contents(): Read of 8192 bytes failed with errno=21 Is a directory in /wp-includes/functions.php on line 6893

wp-includes/functions.php:6893
   file_get_contents()
wp-includes/functions.php:6893
   get_file_data()
wp-admin/includes/plugin.php:94
   get_plugin_data()
wp-content/plugins/simple-history/loggers/class-available-updates-logger.php:158
   Simple_History\Loggers\Available_Updates_Logger->on_setted_update_plugins_transient()
wp-includes/class-wp-hook.php:326
   do_action('set_site_transient_update_plugins')
wp-includes/option.php:2661
   set_site_transient()
wp-includes/update.php:393
   wp_update_plugins()
wp-includes/class-wp-hook.php:324
   do_action('load-plugins.php')
wp-admin/admin.php:385
```

We encountered this behavior because one of our other plugins (relevanssi-premium) uses `relevanssi-premium` as its plugin slug in its `pre_set_site_transient_update_plugins` hook, instead of the slug with the full path `relevanssi-premium/relevanssi.php`. This causes Simple History to fail its lookup of plugin data: https://github.com/bonny/WordPress-Simple-History/blob/main/loggers/class-available-updates-logger.php#L156

This pull request modifies the earlier `file_exists()` check to `is_file()`, since `file_exists()` will return true for both directories and files. We only want to proceed past this check if an actual file is found, not a directory (which is the case with the `relevanssi-premium` slug above).
https://www.php.net/manual/en/function.file-exists.php

Thanks for the awesome plugin and let us know if we can provide more details! Cheers
