### PR TITLE
Fix PHP Notice (wpdb::prepare was called incorrectly)

### DIFF
--- a/inc/class-events-stats.php
+++ b/inc/class-events-stats.php
@@ -1609,9 +1609,7 @@ class Events_Stats {
 		global $wpdb;
 
 		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT * FROM {$wpdb->prefix}simple_history ORDER BY date ASC LIMIT 1"
-			),
+			"SELECT * FROM {$wpdb->prefix}simple_history ORDER BY date ASC LIMIT 1",
 			ARRAY_A
 		);
 


### PR DESCRIPTION
```
PHP Notice:  Function wpdb::prepare was called <strong>incorrectly</strong>. The query argument of wpdb::prepare() must have a placeholder. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.9.0.) in [redacted]/wp-includes/functions.php on line 6085
```