### PR TITLE
Fix PHP 8 TypeError in is_form_submitted_from_permalink_page()

### DIFF
--- a/loggers/class-options-logger.php
+++ b/loggers/class-options-logger.php
@@ -279,7 +279,8 @@ class Options_Logger extends Logger {
 	 * @return bool
 	 */
 	protected function is_form_submitted_from_permalink_page() {
-		return strpos( wp_get_referer(), 'options-permalink.php' ) !== false;
+		$referer = wp_get_referer();
+		return $referer && strpos( $referer, 'options-permalink.php' ) !== false;
 	}
 
 	/**


### PR DESCRIPTION
Hey Pär,

wp_get_referer() returns false when no valid referer is present (REST API calls, WP-CLI, anything without a Referer header). In is_form_submitted_from_permalink_page(), that false gets passed directly to strpos() — which throws a TypeError on PHP 8. Fix is to store the return value first and short-circuit on false before calling strpos().

(full disclosure, I used AI help with the testing and tweaks - Christopher)