### PR TITLE
Make text strings translateable

### DIFF
--- a/inc/class-stats-view.php
+++ b/inc/class-stats-view.php
@@ -68,18 +68,27 @@ class Stats_View {
 
 			<div class="sh-StatsDashboard-dateRangeControls">
 				<select>
-					<option disabled>Today</option>
-					<option disabled>Last 7 days</option>
-					<option selected>Last 30 days</option>
-					<option disabled>Last 3 months</option>
-					<option disabled>Last 6 months</option>
-					<option disabled>Last year</option>
-					<option disabled>All time</option>
+					<option disabled><?php esc_html_e( 'Today', 'simple-history' ); ?></option>
+					<option disabled><?php esc_html_e( 'Last 7 days', 'simple-history' ); ?></option>
+					<option selected><?php esc_html_e( 'Last 30 days', 'simple-history' ); ?></option>
+					<option disabled><?php esc_html_e( 'Last 3 months', 'simple-history' ); ?></option>
+					<option disabled><?php esc_html_e( 'Last 6 months', 'simple-history' ); ?></option>
+					<option disabled><?php esc_html_e( 'Last year', 'simple-history' ); ?></option>
+					<option disabled><?php esc_html_e( 'All time', 'simple-history' ); ?></option>
 				</select>
 
 				<div class="sh-StatsDashboard-dateRangeControls-description">
 					<span class="sh-Icon sh-Icon-lock"></span>
-					<span><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( Helpers::get_tracking_url( 'https://simple-history.com/add-ons/premium/', 'premium_stats_daterange' ) ); ?>">Upgrade to Premium</a> to get access to more date ranges.</span>
+					<span>
+						<?php
+							printf(
+								/* translators: 1: opening link tag, 2: closing link tag */
+								__( '%1$sUpgrade to Premium%2$s to get access to more date ranges.', 'simple-history' ),
+								'<a target="_blank" rel="noopener noreferrer" href="' . esc_url( Helpers::get_tracking_url( 'https://simple-history.com/add-ons/premium/', 'premium_stats_daterange' ) ) . '">', // 1
+								'</a>', // 2
+							);
+						?>
+					</span>
 				</div>
 			</div>
 
@@ -136,8 +145,8 @@ class Stats_View {
 					<span class="sh-StatsDashboard-statLabel"><?php esc_html_e( 'Users with most events', 'simple-history' ); ?></span>
 					<span class="sh-StatsDashboard-statValue"><?php self::output_top_users_avatar_list( $top_users ); ?></span>
 				</div>
-			</div>		
-			
+			</div>
+
 			<div class="sh-flex sh-justify-between sh-mb-large">
 				<?php
 				/*
@@ -176,7 +185,7 @@ class Stats_View {
 				}
 				?>
 			</div>
-	
+
 			<div class="sh-StatsDashboard-stat">
 				<div class="sh-StatsDashboard-statLabel">
 					<?php esc_html_e( 'Activity by date', 'simple-history' ); ?>
@@ -320,14 +329,14 @@ class Stats_View {
 	public static function output_top_posts_and_pages_section( $top_posts_and_pages ) {
 		?>
 		<div class="sh-StatsDashboard-card sh-StatsDashboard-card--wide">
-			<h2 
-				class="sh-StatsDashboard-cardTitle" 
+			<h2
+				class="sh-StatsDashboard-cardTitle"
 				style="--sh-badge-background-color: var(--sh-color-green-light);"
 			>
 				<?php echo esc_html_x( 'Most edited posts and pages', 'stats section title', 'simple-history' ); ?>
 			</h2>
 
-			<p>Events can be page created, updated, deleted, trashed or restored.</p>
+			<p><?php esc_html_e( 'Events can be page created, updated, deleted, trashed or restored.', 'simple-history' ); ?></p>
 
 			<div class="sh-StatsDashboard-content">
 				<?php
@@ -424,7 +433,15 @@ class Stats_View {
 						>
 						<span class="sh-StatsDashboard-userData">
 							<span class="sh-StatsDashboard-userName"><?php echo esc_html( $user['display_name'] ); ?></span>
-							<span class="sh-StatsDashboard-userActions"><?php echo esc_html( number_format_i18n( $user['count'] ) ); ?> events</span>
+							<span class="sh-StatsDashboard-userActions">
+								<?php
+									printf(
+										/* translators: %d: number of events */
+										esc_html( _n( '%d event', '%d events', $user['count'], 'simple-history' ) ),
+										number_format_i18n( $user['count'] )
+									);
+								?>
+							</span>
 						</span>
 					</a>
 				</li>
@@ -518,7 +535,7 @@ class Stats_View {
 		?>
 		<div class="sh-StatsDashboard-card">
 			<h2
-			class="sh-StatsDashboard-cardTitle" 
+			class="sh-StatsDashboard-cardTitle"
 			style="
 					--sh-badge-background-color: var(--sh-color-green-light);
 					--sh-icon-size: 14px;
@@ -529,7 +546,7 @@ class Stats_View {
 			</h2>
 
 			<p class="sh-mt-0">
-				Premium users get access to charts with detailed stats.
+				<?php esc_html_e( 'Premium users get access to charts with detailed stats.', 'simple-history' ); ?>
 				<a href="<?php echo esc_url( Helpers::get_tracking_url( 'https://simple-history.com/add-ons/premium/#stats-and-summaries', 'premium_stats_charts' ) ); ?>" class="sh-ml-1" target="_blank"><?php esc_html_e( 'View more details', 'simple-history' ); ?></a>.
 			</p>
 
@@ -660,8 +677,8 @@ class Stats_View {
 	public static function output_stats_box_section( $title, $stats, $color_var, $description_text = '' ) {
 		?>
 		<div class="sh-StatsDashboard-card sh-StatsDashboard-card--wide">
-			<h2 
-				class="sh-StatsDashboard-cardTitle" 
+			<h2
+				class="sh-StatsDashboard-cardTitle"
 				style="
 					--sh-badge-background-color: var(<?php echo esc_attr( $color_var ); ?>);
 					--sh-icon-size: 14px;
@@ -681,7 +698,7 @@ class Stats_View {
 				<?php
 			}
 			?>
-			
+
 			<div class="sh-StatsDashboard-content">
 				<div class="sh-StatsDashboard-stats is-blurred">
 					<?php

--- a/inc/class-stats-view.php
+++ b/inc/class-stats-view.php
@@ -329,8 +329,8 @@ class Stats_View {
 	public static function output_top_posts_and_pages_section( $top_posts_and_pages ) {
 		?>
 		<div class="sh-StatsDashboard-card sh-StatsDashboard-card--wide">
-			<h2
-				class="sh-StatsDashboard-cardTitle"
+			<h2 
+				class="sh-StatsDashboard-cardTitle" 
 				style="--sh-badge-background-color: var(--sh-color-green-light);"
 			>
 				<?php echo esc_html_x( 'Most edited posts and pages', 'stats section title', 'simple-history' ); ?>
@@ -535,7 +535,7 @@ class Stats_View {
 		?>
 		<div class="sh-StatsDashboard-card">
 			<h2
-			class="sh-StatsDashboard-cardTitle"
+			class="sh-StatsDashboard-cardTitle" 
 			style="
 					--sh-badge-background-color: var(--sh-color-green-light);
 					--sh-icon-size: 14px;
@@ -677,8 +677,8 @@ class Stats_View {
 	public static function output_stats_box_section( $title, $stats, $color_var, $description_text = '' ) {
 		?>
 		<div class="sh-StatsDashboard-card sh-StatsDashboard-card--wide">
-			<h2
-				class="sh-StatsDashboard-cardTitle"
+			<h2 
+				class="sh-StatsDashboard-cardTitle" 
 				style="
 					--sh-badge-background-color: var(<?php echo esc_attr( $color_var ); ?>);
 					--sh-icon-size: 14px;

--- a/inc/class-stats-view.php
+++ b/inc/class-stats-view.php
@@ -752,7 +752,7 @@ class Stats_View {
 			__( 'Plugins', 'simple-history' ),
 			$stats_data,
 			'--sh-color-green-mint',
-			'Premium users get quick overview of vital plugin numbers, like installations, activations, updates, deactivations and deletions.'
+			__( 'Premium users get quick overview of vital plugin numbers, like installations, activations, updates, deactivations and deletions.', 'simple-history' )
 		);
 	}
 
@@ -787,7 +787,7 @@ class Stats_View {
 			_x( 'User profile activity', 'stats section title', 'simple-history' ),
 			$stats_data,
 			'--sh-color-pink',
-			'Premium users get detailed stats on user profile activity, like successful logins, failed logins, profile updates, added users and removed users.'
+			__( 'Premium users get detailed stats on user profile activity, like successful logins, failed logins, profile updates, added users and removed users.', 'simple-history' )
 		);
 	}
 
@@ -818,7 +818,7 @@ class Stats_View {
 			_x( 'Posts & pages activity', 'stats section title', 'simple-history' ),
 			$stats_data,
 			'--sh-color-yellow',
-			'Premium users get detailed stats on posts and pages activity, like created, updated, trashed and deleted.'
+			__( 'Premium users get detailed stats on posts and pages activity, like created, updated, trashed and deleted.', 'simple-history' )
 		);
 	}
 
@@ -845,7 +845,7 @@ class Stats_View {
 			_x( 'Media', 'stats section title', 'simple-history' ),
 			$stats_data,
 			'--sh-color-green-light',
-			'Premium users get detailed stats on media activity, like uploads, edits and deletions.'
+			__( 'Premium users get detailed stats on media activity, like uploads, edits and deletions.', 'simple-history' )
 		);
 	}
 
@@ -869,7 +869,7 @@ class Stats_View {
 			_x( 'Notes', 'stats section title', 'simple-history' ),
 			$stats_data,
 			'--sh-color-blue',
-			'Premium users get detailed stats on collaborative notes activity from the block editor.'
+			__( 'Premium users get detailed stats on collaborative notes activity from the block editor.', 'simple-history' )
 		);
 	}
 

--- a/templates/email-summary-report.php
+++ b/templates/email-summary-report.php
@@ -189,7 +189,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 </head>
 <body style="margin: 0; padding: 0; width: 100%; word-break: break-word; -webkit-font-smoothing: antialiased; background-color: #FFF4E4;">
 
-	<div role="article" aria-roledescription="email" lang="<?php echo esc_attr( get_locale() ); ?>"
+	<div role="article" aria-roledescription="email" lang="<?php echo esc_attr( get_locale() ); ?>" 
 		style="text-size-adjust: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; background-color: #FFF4E4;">
 
 		<!-- Visually Hidden Preheader Text -->
@@ -256,7 +256,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 				<td style="background-color: #ffffff; border-radius: 8px 8px 0 0; box-shadow: 0 2px 8px rgba(0,0,0,0.1);" class="email-container">
 					<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 						<tr>
-							<td style="padding: 30px 40px 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; text-align: center; background-color: #ffffff;"
+							<td style="padding: 30px 40px 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; text-align: center; background-color: #ffffff;" 
 								class="mobile-padding email-container" role="main">
 
 					<!-- Main Headline -->
@@ -276,7 +276,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 						<?php echo esc_html( __( "Here's a summary of activity on your website.", 'simple-history' ) ); ?>
 					</p>
 
-					<p style="margin: 0 0 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 18px; line-height: 26px; color: #000000; text-align: left;"
+					<p style="margin: 0 0 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 18px; line-height: 26px; color: #000000; text-align: left;" 
 						class="mobile-text">
 						<?php
 						$allowed_html = array(
@@ -370,7 +370,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 
 							// Iterate through each day in the range.
 							while ( $current_date <= $end_date ) {
-								$day_name  = wp_date( 'l', $current_date->getTimestamp() ); // Full day name (e.g., "Monday").
+								$day_name   = wp_date( 'l', $current_date->getTimestamp() ); // Full day name (e.g., "Monday").
 								$day_number = (int) $current_date->format( 'w' ); // Day of week (0=Sunday, 6=Saturday).
 
 								// Get full formatted date for tooltip.
@@ -732,7 +732,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 					<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto;">
 						<tr>
 							<td>
-								<a href="<?php echo esc_url( $args['history_admin_url'] ); ?>"
+								<a href="<?php echo esc_url( $args['history_admin_url'] ); ?>" 
 									style="background: #0040FF; border: 16px solid #0040FF; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 16px; line-height: 20px; text-decoration: none; color: #ffffff; display: block; border-radius: 6px; font-weight: 600;">
 									<?php echo esc_html( __( 'View Activity Log', 'simple-history' ) ); ?>
 								</a>

--- a/templates/email-summary-report.php
+++ b/templates/email-summary-report.php
@@ -147,38 +147,38 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 	<![endif]-->
 	<style>
 		table, td, div, h1, p {font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;}
-		
+
 		/* Mobile styles */
 		@media only screen and (max-width: 599px) {
 			.email-container {
 				width: calc(100% - 40px) !important;
 			}
-			
+
 			.fluid {
 				max-width: 100% !important;
 				width: 100% !important;
 				height: auto !important;
 			}
-			
+
 			.mobile-padding {
 				padding: 20px !important;
 			}
-			
+
 			.mobile-text {
 				font-size: 16px !important; line-height: 24px !important;
 			}
-			
+
 			.mobile-header {
 				font-size: 26px !important;
 				line-height: 32px !important;
 			}
-			
+
 			.mobile-stat {
 				display: block !important;
 				width: 100% !important;
 				margin-bottom: 10px !important;
 			}
-			
+
 			.mobile-breakdown {
 				display: block !important;
 				width: 48% !important;
@@ -188,10 +188,10 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 	</style>
 </head>
 <body style="margin: 0; padding: 0; width: 100%; word-break: break-word; -webkit-font-smoothing: antialiased; background-color: #FFF4E4;">
-	
-	<div role="article" aria-roledescription="email" lang="<?php echo esc_attr( get_locale() ); ?>" 
+
+	<div role="article" aria-roledescription="email" lang="<?php echo esc_attr( get_locale() ); ?>"
 		style="text-size-adjust: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; background-color: #FFF4E4;">
-		
+
 		<!-- Visually Hidden Preheader Text -->
 		<div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
 			<?php
@@ -212,10 +212,10 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 			}
 			?>
 		</div>
-		
+
 		<!-- Email Container -->
 		<table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="500" style="margin: auto;" class="email-container">
-			
+
 			<!-- Logo -->
 			<tr>
 				<td style="padding: 40px 0 20px; text-align: left;">
@@ -250,33 +250,33 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 					</table>
 				</td>
 			</tr>
-			
+
 			<!-- White Container Starts -->
 			<tr>
 				<td style="background-color: #ffffff; border-radius: 8px 8px 0 0; box-shadow: 0 2px 8px rgba(0,0,0,0.1);" class="email-container">
 					<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 						<tr>
-							<td style="padding: 30px 40px 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; text-align: center; background-color: #ffffff;" 
+							<td style="padding: 30px 40px 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; text-align: center; background-color: #ffffff;"
 								class="mobile-padding email-container" role="main">
-								
+
 					<!-- Main Headline -->
 					<h1 style="margin: 0 0 10px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 36px; line-height: 42px; color: #000000; font-weight: 600; text-align: left; text-wrap: balance;"
 						class="mobile-header">
 						<?php echo esc_html( __( 'Website activity summary', 'simple-history' ) ); ?>
 					</h1>
-					
+
 					<!-- Date Range -->
 					<p style="margin: 0 0 30px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 14px; line-height: 18px; color: #000000; font-weight: 500; text-transform: uppercase; letter-spacing: 0.5px; text-align: left;">
 						<?php echo esc_html( $args['date_range'] ); ?>
 					</p>
-					
+
 					<!-- Subtitle -->
 					<p style="margin: 0 0 10px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 18px; line-height: 26px; color: #000000; text-align: left;"
 						class="mobile-text">
 						<?php echo esc_html( __( "Here's a summary of activity on your website.", 'simple-history' ) ); ?>
 					</p>
 
-					<p style="margin: 0 0 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 18px; line-height: 26px; color: #000000; text-align: left;" 
+					<p style="margin: 0 0 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 18px; line-height: 26px; color: #000000; text-align: left;"
 						class="mobile-text">
 						<?php
 						$allowed_html = array(
@@ -297,7 +297,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 						);
 						?>
 					</p>
-					
+
 					<?php
 					if ( $show_main_core_stats ) {
 						?>
@@ -340,13 +340,13 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 								<?php echo esc_html( number_format_i18n( $args['total_events_this_week'] ) ); ?>
 							</div>
 						</div>
-						
+
 						<!-- Weekly Activity Breakdown -->
 						<div style="margin-bottom: 30px; padding-bottom: 30px; border-bottom: 2px solid #000000;">
 							<h2 style="margin: 0 0 15px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 20px; line-height: 26px; color: #000000; font-weight: 600; text-align: left;">
 								<?php echo esc_html( __( 'Event count by day', 'simple-history' ) ); ?>
 							</h2>
-							
+
 							<?php
 							// Create a lookup array from most_active_days for easy access.
 							// Data is already keyed by day number (0-6) to avoid language issues.
@@ -370,7 +370,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 
 							// Iterate through each day in the range.
 							while ( $current_date <= $end_date ) {
-								$day_name   = $current_date->format( 'l' ); // Full day name (e.g., "Monday").
+								$day_name  = wp_date( 'l', $current_date->getTimestamp() ); // Full day name (e.g., "Monday").
 								$day_number = (int) $current_date->format( 'w' ); // Day of week (0=Sunday, 6=Saturday).
 
 								// Get full formatted date for tooltip.
@@ -397,7 +397,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 								$current_date = $current_date->modify( '+1 day' );
 							}
 							?>
-							
+
 							<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 								<tr>
 									<?php
@@ -431,7 +431,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 								</tr>
 							</table>
 						</div>
-						
+
 						<!-- Posts Section -->
 						<div style="margin-bottom: 30px; padding-bottom: 30px; border-bottom: 2px solid #000000;">
 							<h2 style="margin: 0 0 15px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 20px; line-height: 26px; color: #000000; font-weight: 600; text-align: left;">
@@ -591,7 +591,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 							<h2 style="margin: 0 0 15px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 20px; line-height: 26px; color: #000000; font-weight: 600; text-align: left;">
 								<?php echo esc_html( __( 'Users', 'simple-history' ) ); ?>
 							</h2>
-							
+
 							<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 								<tr>
 									<td style="width: 50%; vertical-align: top; padding-right: 15px;">
@@ -642,7 +642,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 							<h2 style="margin: 0 0 15px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 20px; line-height: 26px; color: #000000; font-weight: 600; text-align: left;">
 								<?php echo esc_html( __( 'Plugins', 'simple-history' ) ); ?>
 							</h2>
-							
+
 							<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 								<tr>
 									<td style="width: 50%; vertical-align: top; padding-right: 15px;">
@@ -727,19 +727,19 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 					</div>
 
 					<?php echo wp_kses_post( $content_after_core_stats ); ?>
-					
+
 					<!-- View All Events Button -->
 					<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto;">
 						<tr>
 							<td>
-								<a href="<?php echo esc_url( $args['history_admin_url'] ); ?>" 
+								<a href="<?php echo esc_url( $args['history_admin_url'] ); ?>"
 									style="background: #0040FF; border: 16px solid #0040FF; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; font-size: 16px; line-height: 20px; text-decoration: none; color: #ffffff; display: block; border-radius: 6px; font-weight: 600;">
 									<?php echo esc_html( __( 'View Activity Log', 'simple-history' ) ); ?>
 								</a>
 							</td>
 						</tr>
 					</table>
-					
+
 					<!-- Upsell Section -->
 					<?php
 					if ( $show_upsell ) {
@@ -766,9 +766,9 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 						</table>
 					</td>
 				</tr>
-					
+
 		</table>
-		
+
 		<!-- Unsubscribe Text Outside White Container -->
 		<table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="500" style="padding: 40px 0;" class="email-container">
 			<tr>
@@ -808,7 +808,7 @@ $render_inline_teaser = function ( $section, $active_section, $text, $url ) {
 				</td>
 			</tr>
 		</table>
-		
+
 	</div>
 </body>
 </html>


### PR DESCRIPTION
Found some instances of strings not wrapped in WordPress translation functions. 